### PR TITLE
issue-#157-extra-optional-param-docs

### DIFF
--- a/drash/example_code/tutorials/resources/creating_a_resource/users_resource_optional_path_params.ts
+++ b/drash/example_code/tutorials/resources/creating_a_resource/users_resource_optional_path_params.ts
@@ -1,0 +1,20 @@
+import { Drash } from "https://deno.land/x/drash/mod.ts";
+
+export default class UsersResource extends Drash.Http.Resource {
+  static paths = [
+    "/users/:id/:name?/:age?/:city?",
+  ];
+
+  public GET() {
+    this.response.body = "GET request received!";
+
+    const id   = this.request.getPathParam("id");
+    const name = this.request.getPathParam("name");
+    const age  = this.request.getPathParam("age");
+    const city = this.request.getPathParam("city");
+
+    this.response.body += ` You passed in the following path params: |${id}|${name}|${age}|${city}|`;
+
+    return this.response;
+  }
+}

--- a/drash/vue/pages/tutorials/resources/creating_a_resource.vue
+++ b/drash/vue/pages/tutorials/resources/creating_a_resource.vue
@@ -16,6 +16,7 @@ export default {
           "Before You Get Started",
           "Creating A Resource",
           "Path Params",
+          "Optional Path Params",
           "Regular Expression URIs",
         ]
       }
@@ -81,6 +82,42 @@ page-tutorial(
           li
             request(method="get" url="/something")
             | Responds with: Get request received! You passed in the following path param: something
+    div.row
+      div.col
+        hr
+        h2-hash Optional Path Params
+        p Path parameters can also be optional, allowing a resource to accept a URI that doesn't depend on certain parameters, but still wishes to accept the request, with or without them.
+        p
+          code-block-slotted(language="typescript" line_highlight="5")
+            template(v-slot:title) /path/to/your/project/users_resource.ts
+            template(v-slot:code) {{ example_code.users_resource_optional_path_params.contents}}
+        p You can have as many optional parameters as you wish, but required parameters must precede optional parameters.
+        P Examples of URIs that this resource would handle:
+        ul
+          li
+            request(method="get" url="/users/1")
+            | Responds with: Get request received! You passed in the following path params: |1||||
+          li
+            request(method="get" url="/users/1/")
+            | Responds with: Get request received! You passed in the following path params: |1||||
+          li
+            request(method="get" url="/users/1/John")
+            | Responds with: Get request received! You passed in the following path params: |1|John|||
+          li
+            request(method="get" url="/users/1/John/")
+            | Responds with: Get request received! You passed in the following path params: |1|John|||
+          li
+            request(method="get" url="/users/1/John/54")
+            | Responds with: Get request received! You passed in the following path params: |1|John|54||
+          li
+            request(method="get" url="/users/1/John/54/")
+            | Responds with: Get request received! You passed in the following path params: |1|John|54||
+          li
+            request(method="get" url="/users/1/John/54/UK")
+            | Responds with: Get request received! You passed in the following path params: |1|John|54|UK|
+          li
+            request(method="get" url="/users/1/John/54/UK/")
+            | Responds with: Get request received! You passed in the following path params: |1|John|54|UK|
     div.row
       div.col
         hr


### PR DESCRIPTION
Fixes #157 

**Description**

* add extra documentation about optional params to the creating a resource page

**Other Notes**

* The page (added underneath the path params bit, as a new h2 header):

![image](https://user-images.githubusercontent.com/47337480/88723618-1aaea300-d121-11ea-81b5-1a49527f36e8.png)

![image](https://user-images.githubusercontent.com/47337480/88723684-2dc17300-d121-11ea-9761-84da1ab7db9e.png)

![image](https://user-images.githubusercontent.com/47337480/88723699-34e88100-d121-11ea-8ddc-ecdebc5047df.png)


