### PR TITLE
fix: Fix compiler errors multipart form data tutorial in drash

### DIFF
--- a/drash/example_code/tutorials/requests/handling_multipart_form_data_bodies/app.ts
+++ b/drash/example_code/tutorials/requests/handling_multipart_form_data_bodies/app.ts
@@ -13,3 +13,5 @@ server.run({
   hostname: "localhost",
   port: 1447
 });
+
+console.log(`Server running on ${server.hostname}:${server.port}`)

--- a/drash/example_code/tutorials/requests/handling_multipart_form_data_bodies/files_resource.ts
+++ b/drash/example_code/tutorials/requests/handling_multipart_form_data_bodies/files_resource.ts
@@ -10,7 +10,7 @@ export default class HomeResource extends Drash.Http.Resource {
     const decoder = new TextDecoder();
     const file = this.request.getBodyFile("my_file");
 
-    if (!file) {
+    if (!file || !file.content) {
       throw new Drash.Exceptions.HttpException(
         400,
         "This resource requires files to be uploaded via the request body."


### PR DESCRIPTION
Fixes #196 

**Description**

* Changes were make to the `getBodyParam` method that weren't reflected in the docs
