### PR TITLE
docs: Add documentation for the whole create app script

### DIFF
--- a/drash/vue/app.vue
+++ b/drash/vue/app.vue
@@ -55,6 +55,10 @@ export default {
               "Request Cookies": "/tutorials/cookies/request-cookies",
               "Response Cookies": "/tutorials/cookies/response-cookies",
             },
+            "CLI": {
+              "Introduction": "/tutorials/cli/introduction",
+              "Create App": "/tutorials/cli/create-app"
+            },
             "Front-End": {
               "Introduction": "/tutorials/front-end/introduction",
               "Creating A Template": "/tutorials/front-end/creating-a-template",

--- a/drash/vue/pages/tutorials/cli/create_app.vue
+++ b/drash/vue/pages/tutorials/cli/create_app.vue
@@ -1,0 +1,61 @@
+<script>
+  import CodeBlock from "/common/vue/code_block.vue";
+
+
+  export const resource = {
+  paths: [
+    "/tutorials/cli/create-app"
+  ],
+  meta: {
+    title: "Create App",
+  }
+}
+
+export default {
+  data() {
+    return {
+      title: resource.meta.title,
+      toc: [
+        "Before You Get Started",
+        "Usage",
+      ]
+    };
+  },
+  components: {
+    CodeBlock
+  }
+}
+</script>
+
+
+<template lang="pug">
+page(
+  :base_url="this.$base_url"
+  :title="title"
+  :toc="toc"
+)
+  h2-hash Before You Get Started
+  p The <code>create_app.ts</code> script can create a boilerplate project for you, so you can quickly get a drash application up and running, all with a simple command.
+  hr
+  h2-hash Usage
+  p All commands will create the recommended files and directories to hold your project, and will include all the required code to start up a server in an instant.
+  ul
+    li Create an API boilerplate
+      p This will create a boilerplate tailored to a Drash API
+      code-block(title="Terminal" language="shell-session")
+        | $ deno run --allow-run --allow-read --allow-write --allow-net https://deno.land/x/drash@{{ $conf.drash.latest_version }}/create_app.ts --api
+    li Create a Web App boilerplate
+      p This will create a boilerplate tailored to a full web application
+      code-block(title="Terminal" language="shell-session")
+        | $ deno run --allow-run --allow-read --allow-write --allow-net https://deno.land/x/drash@{{ $conf.drash.latest_version }}/create_app.ts --web-app
+      ul
+        li Include React with the frontend
+          p Adding the `--with-react` flag will also setup your project with React, so you do not need to configure webpack or set it up yourself.
+          code-block(title="Terminal" language="shell-session")
+            | $ deno run --allow-run --allow-read --allow-write --allow-net https://deno.land/x/drash@{{ $conf.drash.latest_version }}/create_app.ts --web-app --with-react
+        li Include Vue with the frontend
+          p Adding the `--with-vue` flag will also setup your project with Vue, so you do not need to configure webpack or set it up yourself.
+          code-block(title="Terminal" language="shell-session")
+            | $ deno run --allow-run --allow-read --allow-write --allow-net https://deno.land/x/drash@{{ $conf.drash.latest_version }}/create_app.ts --web-app --with-vue
+
+</template>

--- a/drash/vue/pages/tutorials/cli/introduction.vue
+++ b/drash/vue/pages/tutorials/cli/introduction.vue
@@ -1,0 +1,45 @@
+<script>
+export const resource = {
+  paths: [
+    "/tutorials/cli/introduction"
+  ],
+  meta: {
+    title: "Introduction To The CLI",
+  }
+}
+
+export default {
+  data() {
+    return {
+      title: resource.meta.title,
+      toc: [
+        "Basics",
+        "Commands",
+      ]
+    };
+  },
+}
+</script>
+
+<template lang="pug">
+page(
+  :base_url="this.$base_url"
+  :title="title"
+  :toc="toc"
+)
+  h2-hash Basics
+  p Drash provides a CLI to provide many utilities to aid in the developer experience, when developing Drash applications:
+  ul
+    li Create a boilerplate project
+      ul
+        li With React support
+        li With Vue support
+        li With an API in mind
+        li With a web application in mind
+  p Using the CLI is useful for when you want to take a shortcut to certain tasks you may want to do, and it is very easy and simple to use.
+  hr
+  h2-hash Commands
+  ul
+    li
+      a(:href="$route.path + '/hel'") Create App (create a boilerplate)
+</template>

--- a/drash/vue/sidebar.vue
+++ b/drash/vue/sidebar.vue
@@ -73,6 +73,12 @@ div.c-sidebar
         div.l-submenu-1.hide--soft
           a-base-url(href="/tutorials/logging/logging-to-the-terminal") Logging To The Terminal
           a-base-url(href="/tutorials/logging/logging-to-files") Logging To Files
+        span.sun-heading
+          p.arrow.right
+          a CLI
+        div.l-submenu-1.hide--soft
+          a-base-url(href="/tutorials/cli/introduction") introduction
+          a-base-url(href="/tutorials/cli/create-app") Create App
         span.sub-heading
           p.arrow.right
           a Front-end


### PR DESCRIPTION
Fixes #212 

**Description**

* I ended up adding docs for the whole create app script because there wasn't any

* Made the docs scalable so it would work in Sara's favour when the CLI is documented
