### PR TITLE
[#211-request-getall-docs] Add docs for  the getAll() method for Drash

### DIFF
--- a/drash/vue/app.vue
+++ b/drash/vue/app.vue
@@ -40,6 +40,7 @@ export default {
               "Handling Multipart Bodies": "/tutorials/requests/handling-multipart-bodies",
               "Handling URL Query Params": "/tutorials/requests/handling-url-query-params",
               "Handling Path Params": "/tutorials/requests/handling-path-params",
+              "Get All Params": "/tutorials/requests/get-all-params"
             },
             "Responses": {
               //"Accept Header": "/tutorials/responses/accept-header",

--- a/drash/vue/pages/tutorials/requests/get_all_params.vue
+++ b/drash/vue/pages/tutorials/requests/get_all_params.vue
@@ -1,0 +1,106 @@
+<script>
+export const resource = {
+  paths: ["/tutorials/requests/get-all-params"],
+  meta: {
+    title: "Get All Params",
+    source_code_uri: "/tutorials/requests/get-all-params"
+  }
+}
+
+export default {
+  data() {
+    return {
+      title: resource.meta.title,
+      toc: [
+        "Before You Get Started",
+        "Folder Structure End State",
+        "Steps",
+        "Verification",
+      ]
+    };
+  },
+}
+</script>
+
+<template lang="pug">
+page(
+  :base_url="this.$base_url"
+  :title="title"
+  :toc="toc"
+)
+  h2-hash Before You Get Started
+  p Drash provides a few methods to all parameters for various situations, such as:
+  ul
+    li Get all header params
+    li Get all body params
+    li Get all path params
+    li Get all URL query params
+  code-block(:header="false" language="typescript")
+    | const bodyParams = this.request.getAllBodyParams();
+    | const headerParams = this.request.getAllHeaderParams();
+    | const pathParams = this.request.getAllPathParams();
+    | const queryParams = this.request.getAllUrlQueryParams();
+  hr
+  folder-structure-end-state
+    | ▾ /path/to/your/project/
+    |   app.ts
+    |   home_resource.ts
+  hr
+  h2-hash Steps
+  ol
+    li
+      p Create your resource file. You resource file will retrieve all header, body, query and path parameters for the request.
+      code-block(title="home_resource.ts" language="typescript")
+        | import { Drash } from "https://deno.land/x/drash@{{ $conf.drash.latest_version}}/mod.ts";
+        |
+        | export default class HomeResource extends Drash.Http.Resource {
+        |   static paths = ["/:name/:region"];
+        |
+        |   public POST() {
+        |     const bodyParams = this.request.getAllBodyParams();
+        |     const headerParams = this.request.getAllHeaderParams();
+        |     const pathParams = this.request.getAllPathParams();
+        |     const queryParams = this.request.getAllUrlQueryParams();
+        |     const data = {
+        |       bodyParams,
+        |       headerParams,
+        |       pathParams,
+        |       queryParams
+        |     };
+        |     this.response.body = data;
+        |     return this.response
+        |   }
+        | }
+    li
+      p Create your app file.
+      code-block(title="app.ts" language="typescript")
+        | import { Drash } from "https://deno.land/x/drash@{{ $conf.drash.latest_version}}/mod.ts";
+        | import HomeResource from "./home_resource.ts";
+        |
+        | const server = new Drash.Http.Server({
+        |   resources: [HomeResource]
+        | });
+        |
+        | await server.run({
+        |   hostname: "localhost",
+        |   port: 1337
+        | });
+        |
+        | console.log(`Server running on http://${server.hostname}:${server.port}`);
+  hr
+  h2-hash Verification
+  ol
+    li Run your app.
+      code-block(title="Terminal" language="shell-session")
+        | $ deno run --allow-net app.ts
+    li
+      p Using <code>curl</code> (or similar command), make a <code>POST</code> request to <code>localhost:1447/Edward/UK</code>.
+      code-block(title="Terminal" language="shell-session")
+        | $ curl --header "Content-Type: application/json" \
+        |   --request POST \
+        |   --data '{"name":"Edward","region":"UK"}' \
+        |   localhost:1337/Edward/UK
+      p You should receive the following response (or somewhat similar, could differ based on your host machine):
+      code-block(:header="false" language="shell-session")
+        | {"bodyParams":{"data":{"name":"Edward","region":"UK"},"content_type":"application/json"},"headerParams":{"host":"localhost:1337","user-agent":"curl/7.54.0","accept":"*/*","content-type":"application/json","content-length":"31"},"pathParams":{"name":"Edward","region":"UK"}}
+</template>

--- a/drash/vue/pages/tutorials/requests/get_all_params.vue
+++ b/drash/vue/pages/tutorials/requests/get_all_params.vue
@@ -29,7 +29,7 @@ page(
   :toc="toc"
 )
   h2-hash Before You Get Started
-  p Drash provides a few methods to all parameters for various situations, such as:
+  p Drash provides a few methods to get all parameters in various scenarios, such as:
   ul
     li Get all header params
     li Get all body params


### PR DESCRIPTION
Fixes #211 

**Description**

* Creates a new. page to document all new methods for request object:
    - `getAllUrlQueryParams`
    - `getAllBodyParams`
    - `getAllHeaderParams`
    - `getAllPathParams`
