### PR TITLE
feat: add GTM to all sites

### DIFF
--- a/dmm/index.template.html
+++ b/dmm/index.template.html
@@ -1,6 +1,13 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P6PZWLV');</script>
+  <!-- End Google Tag Manager -->
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, minimum-scale=1.0, user-scalable=no"/>
   <title>dmm</title>
@@ -14,6 +21,10 @@
   <meta name="theme-color" content="#ffffff">
 </head>
 <body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P6PZWLV"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
   <div class="hide--soft" id="vue_app_mount">
     <vue-app-root></vue-app-root>
   </div>

--- a/drash/index.template.html
+++ b/drash/index.template.html
@@ -1,6 +1,13 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P6PZWLV');</script>
+  <!-- End Google Tag Manager -->
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, minimum-scale=1.0, user-scalable=no"/>
   <title>Drash</title>
@@ -14,6 +21,10 @@
   <meta name="theme-color" content="#ffffff">
 </head>
 <body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P6PZWLV"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
   <div class="hide--soft" id="vue_app_mount">
     <vue-app-root></vue-app-root>
   </div>

--- a/rhum/index.template.html
+++ b/rhum/index.template.html
@@ -1,6 +1,13 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P6PZWLV');</script>
+  <!-- End Google Tag Manager -->
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, minimum-scale=1.0, user-scalable=no"/>
   <title>Rhum</title>
@@ -14,6 +21,10 @@
   <meta name="theme-color" content="#ffffff">
 </head>
 <body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P6PZWLV"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
   <div class="hide--soft" id="vue_app_mount">
     <vue-app-root></vue-app-root>
   </div>

--- a/sockets/index.html
+++ b/sockets/index.html
@@ -1,6 +1,13 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P6PZWLV');</script>
+  <!-- End Google Tag Manager -->
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, minimum-scale=1.0, user-scalable=no"/>
   <title>Sockets</title>
@@ -14,6 +21,10 @@
   <meta name="theme-color" content="#ffffff">
 </head>
 <body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P6PZWLV"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
   <div class="hide--soft" id="vue_app_mount">
     <vue-app-root></vue-app-root>
   </div>


### PR DESCRIPTION
Closes #238 

**Description**

* Adds Google Tag Manager (GTM) tag to the site for page views and user interactions like what they're clicking
* GTM is managed through the GTM dashboard
