### PR TITLE
fix: make sure denon kills server before trying to run it again

### DIFF
--- a/serve.ts
+++ b/serve.ts
@@ -1,15 +1,22 @@
-const a = await Deno.run({
-  cmd: ["console/compile_vue_routes"],
-  stderr: "piped",
-});
+const decoder = new TextDecoder();
 
-await a.status()
-a.close()
+await run(["console/compile_vue_routes"])
 
-const b = await Deno.run({
-  cmd: ["deno", "run", "-A", "app.ts"],
-  stderr: "piped",
-});
+await run(["pkill", "-f", "drash_website_server.ts"]);
 
-await b.status()
-b.close()
+await run(["deno", "run", "-A", "drash_website_server.ts"]);
+
+async function run(command: string[]) {
+  const p = Deno.run({
+    cmd: command,
+    stderr: "piped",
+  });
+
+  const status = await p.status()
+
+  if (status.code === 1) {
+    console.log(decoder.decode(await p.stderrOutput()));
+  }
+
+  p.close();
+}


### PR DESCRIPTION
Makes sure denon can restart the server. Currently, denon throws an error stating that the address is still in use. This PR makes sure denon kills the server before trying to run it again -- using `pkill -f drash_website_server.ts`. `app.ts` was renamed to `drash_website_server.ts` so that `pkill -f` doesn't kill any `app.ts` that you might be running elsewhere.