### PR TITLE
fix: rename app.ts to drash_website_server.ts

### DIFF
--- a/drash_website_server.ts
+++ b/drash_website_server.ts
@@ -8,7 +8,7 @@ Drash.Http.Response = Response
 const server = new Drash.Http.Server({
   resources: [
       LandingResource,
-      DrashResource
+      DrashResource,
   ],
   response_output: "text/html",
   static_paths: [


### PR DESCRIPTION
This PR complies with the last PR. The last PR expects `drash_website_server.ts`. This PR meets that expectation.