### PR TITLE
fix build scripts for dev env

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ $ git checkout drash-v1.x
 3. Run the development server.
 
 ```
-$ npm run dev:server
+$ npm run dev:server <module>-<version>
 ```
 
 4. Run webpack
 
 ```
-$ npm run dev:webpack
+$ npm run dev:webpack <module>-<version>
 ```
 
 ## Setting Up An Environment

--- a/console/build_docs
+++ b/console/build_docs
@@ -3,7 +3,7 @@
 BRANCH="$(git branch --show-current)"
 PARENT_BRANCH="$1"
 
-echo -e "Building bundles for $BRANCH under $PARENT_BRANCH"
+echo -e "Building bundles for $PARENT_BRANCH/$BRANCH"
 
 node console/compile_vue_routes.js $PARENT_BRANCH
 

--- a/console/build_docs
+++ b/console/build_docs
@@ -1,12 +1,13 @@
 #!/bin/bash
 
 BRANCH="$(git branch --show-current)"
+PARENT_BRANCH="$1"
 
-echo -e "Building bundles for $BRANCH"
+echo -e "Building bundles for $BRANCH under $PARENT_BRANCH"
 
-node console/compile_vue_routes.js $BRANCH
+node console/compile_vue_routes.js $PARENT_BRANCH
 
 node_modules/.bin/webpack \
   --config ./configs.webpack.production.js \
   --hide-modules \
-  --env.branch=$BRANCH \
+  --env.branch=$PARENT_BRANCH \

--- a/console/build_docs.ts
+++ b/console/build_docs.ts
@@ -2,11 +2,10 @@ import { buildDocs, run } from "./scripts.ts";
 
 const args = Deno.args.slice();
 const branch = args[0];
-
 const parentBranch = `${args[1]}-${args[2]}`;
 
-console.log(`Building docs for ${branch} under ${parentBranch}`);
+console.log(`Building docs for ${parentBranch}/${branch}`);
 
 await run(["npm", "install"]);
 
-await buildDocs(branch, parentBranch);
+await buildDocs(parentBranch);

--- a/console/build_docs.ts
+++ b/console/build_docs.ts
@@ -3,8 +3,10 @@ import { buildDocs, run } from "./scripts.ts";
 const args = Deno.args.slice();
 const branch = args[0];
 
-console.log(`Building docs for ${branch}`);
+const parentBranch = `${args[1]}-${args[2]}`;
+
+console.log(`Building docs for ${branch} under ${parentBranch}`);
 
 await run(["npm", "install"]);
 
-await buildDocs(branch);
+await buildDocs(branch, parentBranch);

--- a/console/scripts.ts
+++ b/console/scripts.ts
@@ -3,11 +3,11 @@ const decoder = new TextDecoder();
 /**
  * Build documentation pages for the specified branch.
  */
-export async function buildDocs(branch: string = "") {
+export async function buildDocs(branch: string = "", parentBranch: string = "") {
   if (branch != "") {
     await run(["git", "checkout", branch]);
   }
-  await run(["console/build_docs"]);
+  await run(["console/build_docs", parentBranch]);
 }
 
 /**

--- a/console/scripts.ts
+++ b/console/scripts.ts
@@ -2,10 +2,12 @@ const decoder = new TextDecoder();
 
 /**
  * Build documentation pages for the specified branch.
+ *
+ * @param parentBranch - One of the parent branches (e.g., rhum-v1.x).
  */
-export async function buildDocs(branch: string = "", parentBranch: string = "") {
-  if (branch != "") {
-    await run(["git", "checkout", branch]);
+export async function buildDocs(parentBranch: string = "") {
+  if (parentBranch != "") {
+    await run(["git", "checkout", parentBranch]);
   }
   await run(["console/build_docs", parentBranch]);
 }
@@ -13,11 +15,10 @@ export async function buildDocs(branch: string = "", parentBranch: string = "") 
 /**
  * Merge main into the specified branch
  *
- * @param moduleName - The name of the module.
- * @param moduleVersion - The version to build (e.g., v1.x).
+ * @param parentBranch - One of the parent branches (e.g., rhum-v1.x).
  */
-export async function gitMergeMainInto(branch: string) {
-  await run(["git", "checkout", branch]);
+export async function gitMergeMainInto(parentBranch: string) {
+  await run(["git", "checkout", parentBranch]);
   await run(["git", "merge", "--no-ff", "main", "-m", "update with main branch"]);
   await run(["git", "push"]);
 }

--- a/console/serve_dev.ts
+++ b/console/serve_dev.ts
@@ -3,10 +3,11 @@ import { run } from "./scripts.ts";
 const args = Deno.args.slice();
 
 const branch = args[0];
+const parentBranch = args[1];
 const moduleName = branch.split("-")[0];
 const moduleVersion = branch.split("-")[1];
 
-await run(["node", "console/compile_vue_routes.js", args[0]]);
+await run(["node", "console/compile_vue_routes.js", parentBranch]);
 
 await run(["pkill", "-f", "drash_website_server.ts"]);
 

--- a/console/serve_dev.ts
+++ b/console/serve_dev.ts
@@ -1,9 +1,9 @@
 import { run } from "./scripts.ts";
 
 const args = Deno.args.slice();
-const parentBranch = args[1]; // e.g., rhum-v1.x
+const branch = args[0]; // e.g., rhum-v1.x
 
-await run(["node", "console/compile_vue_routes.js", parentBranch]);
+await run(["node", "console/compile_vue_routes.js", branch]);
 
 await run(["pkill", "-f", "drash_website_server.ts"]);
 

--- a/console/serve_dev.ts
+++ b/console/serve_dev.ts
@@ -1,9 +1,9 @@
 import { run } from "./scripts.ts";
 
 const args = Deno.args.slice();
-const branch = args[0]; // e.g., rhum-v1.x
+const parentBranch = args[0]; // e.g., rhum-v1.x
 
-await run(["node", "console/compile_vue_routes.js", branch]);
+await run(["node", "console/compile_vue_routes.js", parentBranch]);
 
 await run(["pkill", "-f", "drash_website_server.ts"]);
 

--- a/console/serve_dev.ts
+++ b/console/serve_dev.ts
@@ -1,11 +1,7 @@
 import { run } from "./scripts.ts";
 
 const args = Deno.args.slice();
-
-const branch = args[0];
-const parentBranch = args[1];
-const moduleName = branch.split("-")[0];
-const moduleVersion = branch.split("-")[1];
+const parentBranch = args[1]; // e.g., rhum-v1.x
 
 await run(["node", "console/compile_vue_routes.js", parentBranch]);
 

--- a/console/webpack
+++ b/console/webpack
@@ -1,13 +1,14 @@
 #!/bin/bash
 
 BRANCH="$(git branch --show-current)"
+PARENT_BRANCH="$1"
 
-echo -e "Building bundles for $BRANCH"
+echo -e "Building bundles for $PARENT_BRANCH/$BRANCH"
 
-node console/compile_vue_routes.js $BRANCH
+node console/compile_vue_routes.js $PARENT_BRANCH
 
 node_modules/.bin/webpack \
   --config ./configs.webpack.development.js \
   --hide-modules \
-  --env.branch=$BRANCH \
+  --env.branch=$PARENT_BRANCH \
   --watch

--- a/deps.ts
+++ b/deps.ts
@@ -1,4 +1,4 @@
 export const decoder = new TextDecoder();
 export const encoder = new TextEncoder();
-export { Drash } from "https://deno.land/x/drash@v1.3.0/mod.ts"
+export { Drash } from "https://deno.land/x/drash@v1.3.1/mod.ts"
 export { configs } from "./configs.js";

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build:docs": "deno run --allow-read --allow-run console/build_docs.ts $(git branch --show-current)",
     "build:ecosystem": "deno run --allow-read --allow-run --allow-write console/build_ecosystem.ts",
-    "dev:server": "denon run -A console/serve_dev.ts $(git branch --show-current)",
+    "dev:server": "denon run -A console/serve_dev.ts",
     "dev:webpack": "console/webpack",
     "git:merge-main": "deno run --allow-run console/git_merge_main.ts",
     "git:pull-all": "deno run --allow-run console/git_pull_all.ts",


### PR DESCRIPTION
I was a bit overzealous with using `git branch --show-current`. This PR changes that and allows us to create feature branches and build docs for the feature branches.

To run the dev server:

```
npm run dev:server <module>-<version>
# e.g., npm run dev:server rhum-v1.x
```

To run webpack for the dev server:

```
npm run dev:webpack <module>-<version>
# e.g., npm run dev:webpack rhum-v1.x
```