### PR TITLE
chore:  Improvements

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,0 +1,67 @@
+name: Master
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+jobs:
+  tests:
+    runs-on: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Server Integration Tests
+        run: |
+          deno test -A tests/integration
+
+  builds:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: build:docs script works
+        run: |
+          git checkout rhum-v1.x
+          npm run build:docs rhum-v1.x
+          git checkout drash-v1.x
+          npm run build:docs drash-v1.x
+          git checkout wocket-v0.x
+          npm run build:docs wocket-v0.x
+          git checkout sinco-v1.x
+          npm run build:docs sinco-v1.x
+          git checkout main
+
+      - name: dev:webpack script works
+        run: |
+          git checkout rhum-v1.x
+          npm run dev:webpack rhum-v1.x
+          git checkout drash-v1.x
+          npm run dev:webpack drash-v1.x
+          git checkout wocket-v0.x
+          npm run dev:webpack wocket-v0.x
+          git checkout sinco-v1.x
+          npm run dev:webpack sinco-v1.x
+          git checkout main
+
+      - name: build:ecosystem script works
+        run: npm run build:ecosystem
+
+      - name: Drash Server Runs
+        run: |
+          echo "server.close()" >> app.ts
+          deno run -A app.ts
+
+  linter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Formatter
+        run: deno fmt --ignore=assets,console/compile_vue_routes.js,configs.webpack.js,console/update_module_versions.js,configs.node.js,ecosystem.config.sample.js
+
+      - name: Linter
+        run: deno lint --unstable --ignore=assets,console/compile_vue_routes.js,configs.webpack.js,console/update_module_versions.js,configs.node.js,ecosystem.config.sample.js

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -64,4 +64,5 @@ jobs:
         run: deno fmt --ignore=assets,console/compile_vue_routes.js,configs.webpack.js,console/update_module_versions.js,configs.node.js,ecosystem.config.sample.js
 
       - name: Linter
-        run: deno lint --unstable --ignore=assets,console/compile_vue_routes.js,configs.webpack.js,console/update_module_versions.js,configs.node.js,ecosystem.config.sample.js
+        # command to use in dev (if you've ran builds and created compiled files): deno lint --unstable --ignore=assets,console/compile_vue_routes.js,configs.webpack.js,console/update_module_versions.js,configs.node.js,ecosystem.config.sample.js,configs.webpack.common.js,configs.webpack.development.js,ecosystem.config.js,node_modules
+        run: deno lint --unstable --ignore=assets,console/compile_vue_routes.js,configs.webpack.js,console/update_module_versions.js,configs.node.js,ecosystem.config.sample.js,configs.webpack.common.js,configs.webpack.development.js

--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@
 ## Table Of Contents
 
 * [Requirements](#requirements)
+* [Versioned Docs Overview](#versioned-docs-overview)
 * [Running The Development Environment](#running-the-development-environment)
-* [Setting Up An Environment](#setting-up-an-environment)
-    * [Build The Environment](#build-the-environment)
-    * [Run The Environment Online](#run-the-environment-online)
+* [Setting Up The Whole Environment](#setting-up-the-whole-environment)
+* [Updating Staging/Prod](#updating-stagingprod)
+* [Creating A New Major Version](#creating-a-new-major-version)
 * [Scripts](#scripts)
 * [Technology Stack](#technology-stack)
 
@@ -16,7 +17,13 @@
 * Node v12.x (use this version to prevent `node-sass` errors)
 * Deno v1.5.4+
 
+## Versioned Docs Overview
+
+To achieve versioned documentation, every module has it's own branch for each major version. These branches hold the source code (the Vue files) for the documentation of that module, and these branches are just used to create a bundled file, which the frontend will use to display the documentation
+
 ## Running The Development Environment
+
+This is specifically for working on a specific module, and will only 'refresh' the code  for that module.
 
 1. Install npm dependencies.
 
@@ -38,15 +45,15 @@ $ npm run dev:server <module>-<version>
 
 4. Run webpack
 
+Note: Must be in a separate window
+
 ```
-$ npm run dev:webpack <module>-<version>
+$ npm run dev:webpack <module>-<version> watch
 ```
 
-## Setting Up An Environment
+## Setting Up The Whole Environment
 
 In the event you want to build an environment (e.g., staging, production, QA), you will need to take the following steps:
-
-### Build The Environment
 
 1. Clone the repo and go into it.
 
@@ -73,32 +80,46 @@ $ npm run build:ecosystem
 $ deno run --allow-net --allow-read drash_website_server.ts
 ```
 
-### Run The Environment Online
+5. (optional) Setup for Staging/Production
 
-1. Set up a web server to handle serving the website application. The website application runs on `localhost:1445`.
+    5.1. Set up a web server to handle serving the website application. The website application runs on `localhost:1445`.
 
     * For Apache: https://github.com/drashland/website/blob/main/apache.conf
     * For Nginx: _In progress_
 
-2. Install [PM2](https://pm2.keymetrics.io/).
+    5.2. Install [PM2](https://pm2.keymetrics.io/).
 
-3. Make a copy of `ecosystem.config.sample.js` to `ecosystem.config.js`. Edit your copied file as necessary. Make sure the `cwd` field properly points to your website repository clone.
+    5.3. Make a copy of `ecosystem.config.sample.js` to `ecosystem.config.js`. Edit your copied file as necessary. Make sure the `cwd` field properly points to your website repository clone.
 
-3. Run PM2. PM2 will use your `ecosystem.config.js` file to start the website application and keep your application online 24/7.
+    5.4. Run PM2. PM2 will use your `ecosystem.config.js` file to start the website application and keep your application online 24/7.
 
-```
-$ pm2 start
+    ```
+    $ pm2 start
+    
+    [PM2] Spawning PM2 daemon with pm2_home=/home/someone/.pm2
+    [PM2] PM2 Successfully daemonized
+    [PM2][WARN] Applications Drash Land (localhost:1445) not running, starting...
+    [PM2] App [Drash Land (localhost:1445)] launched (1 instances)
+    ┌─────┬────────────────────────────────┬─────────────┬─────────┬─────────┬──────────┬────────┬──────┬───────────┬──────────┬──────────┬──────────┬──────────┐
+    │ id  │ name                           │ namespace   │ version │ mode    │ pid      │ uptime │ ↺    │ status    │ cpu      │ mem      │ user     │ watching │
+    ├─────┼────────────────────────────────┼─────────────┼─────────┼─────────┼──────────┼────────┼──────┼───────────┼──────────┼──────────┼──────────┼──────────┤
+    │ 0   │ Drash Land (localhost:1445)    │ default     │ N/A     │ fork    │ 228260   │ 0s     │ 0    │ online    │ 0%       │ 24.8mb   │ someone  │ enabled  │
+    └─────┴────────────────────────────────┴─────────────┴─────────┴─────────┴──────────┴────────┴──────┴───────────┴──────────┴──────────┴──────────┴──────────┘
+    ```
+   
+## Updating Staging/Prod
 
-[PM2] Spawning PM2 daemon with pm2_home=/home/someone/.pm2
-[PM2] PM2 Successfully daemonized
-[PM2][WARN] Applications Drash Land (localhost:1445) not running, starting...
-[PM2] App [Drash Land (localhost:1445)] launched (1 instances)
-┌─────┬────────────────────────────────┬─────────────┬─────────┬─────────┬──────────┬────────┬──────┬───────────┬──────────┬──────────┬──────────┬──────────┐
-│ id  │ name                           │ namespace   │ version │ mode    │ pid      │ uptime │ ↺    │ status    │ cpu      │ mem      │ user     │ watching │
-├─────┼────────────────────────────────┼─────────────┼─────────┼─────────┼──────────┼────────┼──────┼───────────┼──────────┼──────────┼──────────┼──────────┤
-│ 0   │ Drash Land (localhost:1445)    │ default     │ N/A     │ fork    │ 228260   │ 0s     │ 0    │ online    │ 0%       │ 24.8mb   │ someone  │ enabled  │
-└─────┴────────────────────────────────┴─────────────┴─────────┴─────────┴──────────┴────────┴──────┴───────────┴──────────┴──────────┴──────────┴──────────┘
-```
+1. Ssh onto the respective server
+
+2. Pull all module branches to update the local source code: `npm run git:pull-all`
+
+3. Rebuild the ecosystem: `npm run build:ecosystem`
+
+4. Restart pm2: `pm2 restart <id|name>`
+   
+## Creating A New Major Version
+
+TODO
 
 ## Scripts
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ $ npm run build:ecosystem
 4. Test that the environment works.
 
 ```
-$ deno run --allow-net --allow-read drash_website_server.ts
+$ deno run --allow-net --allow-read app.ts
 ```
 
 5. (optional) Setup for Staging/Production

--- a/app.ts
+++ b/app.ts
@@ -1,8 +1,8 @@
-import {server} from "./server.ts";
+import { server } from "./server.ts";
 
 await server.run({
   hostname: "localhost",
-  port: 1445
+  port: 1445,
 });
 
-console.log(`Running server on http://${server.hostname}:${server.port}`)
+console.log(`Running server on http://${server.hostname}:${server.port}`);

--- a/app.ts
+++ b/app.ts
@@ -1,0 +1,8 @@
+import {server} from "./server.ts";
+
+await server.run({
+  hostname: "localhost",
+  port: 1445
+});
+
+console.log(`Running server on http://${server.hostname}:${server.port}`)

--- a/configs.js
+++ b/configs.js
@@ -2,10 +2,10 @@ export const configs = {
   "copyright_year": "2020",
   "root_directory": ".",
   "deno": {
-    "latest_version": "v1.5.3"
+    "latest_version": "v1.5.3",
   },
   "deno_std": {
-    "latest_version": "0.78.0"
+    "latest_version": "0.78.0",
   },
   "dmm": {
     "base_url": "/dmm/v1.x",
@@ -13,8 +13,8 @@ export const configs = {
     "latest_url_deno_land": "https://deno.land/x/dmm@v1.2.0/mod.ts",
     "latest_url_nest_land": "https://x.nest.land/dmm@v1.2.0/mod.ts",
     "versions": [
-      "v1.x"
-    ]
+      "v1.x",
+    ],
   },
   "drash": {
     "base_url": "/drash/v1.x",
@@ -22,8 +22,8 @@ export const configs = {
     "latest_url_deno_land": "https://deno.land/x/drash@v1.3.1/mod.ts",
     "latest_url_nest_land": "https://x.nest.land/deno-drash@v1.3.1/mod.ts",
     "versions": [
-      "v1.x"
-    ]
+      "v1.x",
+    ],
   },
   "rhum": {
     "base_url": "/rhum/v1.x",
@@ -31,8 +31,8 @@ export const configs = {
     "latest_url_deno_land": "https://deno.land/x/rhum@v1.1.6/mod.ts",
     "latest_url_nest_land": "https://x.nest.land/rhum@v1.1.6/mod.ts",
     "versions": [
-      "v1.x"
-    ]
+      "v1.x",
+    ],
   },
   "wocket": {
     "base_url": "/wocket/v0.x",
@@ -40,16 +40,16 @@ export const configs = {
     "latest_url_deno_land": "https://deno.land/x/wocket@v0.6.2/mod.ts",
     "latest_url_nest_land": "https://x.nest.land/wocket@v0.6.2/mod.ts",
     "versions": [
-      "v0.x"
-    ]
+      "v0.x",
+    ],
   },
   "sinco": {
     "base_url": "/sinco/v1.x",
     "latest_version": "v1.0.0",
     "versions": [
-      "v1.x"
+      "v1.x",
     ],
     "latest_url_deno_land": "https://deno.land/x/sinco@v1.0.0/mod.ts",
-    "latest_url_nest_land": "https://x.nest.land/sinco@v1.0.0/mod.ts"
-  }
+    "latest_url_nest_land": "https://x.nest.land/sinco@v1.0.0/mod.ts",
+  },
 };

--- a/configs.webpack.common.js
+++ b/configs.webpack.common.js
@@ -38,11 +38,11 @@ module.exports = {
   },
   optimization: {
     splitChunks: {
-      chunks: 'all',
+      chunks: "all",
     },
   },
   plugins: [
     // make sure to include the plugin!
     new VueLoaderPlugin(),
-  ]
+  ],
 };

--- a/configs.webpack.development.js
+++ b/configs.webpack.development.js
@@ -14,7 +14,8 @@ module.exports = (envVars) => {
   console.log(
     `Building webpack bundle...
 Mode: development (JS code will not be minified)
-Bundle: ${module}.${version}.js`);
+Bundle: ${module}.${version}.js`,
+  );
 
   return Object.assign(configsCommon, {
     entry: {

--- a/console/build_ecosystem.ts
+++ b/console/build_ecosystem.ts
@@ -1,5 +1,5 @@
 import { decoder, encoder } from "../deps.ts";
-import {buildDocs, exists, run} from "./scripts.ts";
+import { buildDocs, exists, run } from "./scripts.ts";
 
 console.log("Building ecosystem...");
 
@@ -15,7 +15,7 @@ const branches = [
   "drash-v1.x",
   "rhum-v1.x",
   "wocket-v0.x",
-  "sinco-v1.x"
+  "sinco-v1.x",
 ];
 for (const i in branches) {
   const branch = branches[i];
@@ -26,7 +26,9 @@ for (const i in branches) {
 // script is done running
 if (await exists("./ecosystem.config.js") === false) {
   console.log("Creating ecosystem.config.js for PM2...");
-  let configs = decoder.decode(await Deno.readFile("ecosystem.config.sample.js"));
+  let configs = decoder.decode(
+    await Deno.readFile("ecosystem.config.sample.js"),
+  );
   configs = configs.replace(/\/path\/to\/website/g, Deno.cwd());
   await Deno.writeFile("./ecosystem.config.js", encoder.encode(configs));
 }

--- a/console/build_ecosystem.ts
+++ b/console/build_ecosystem.ts
@@ -1,5 +1,5 @@
 import { decoder, encoder } from "../deps.ts";
-import { buildDocs, run } from "./scripts.ts";
+import {buildDocs, exists, run} from "./scripts.ts";
 
 console.log("Building ecosystem...");
 
@@ -24,9 +24,11 @@ for (const i in branches) {
 
 // Create the PM2 ecosystem file so that we can run `pm2 start` after this
 // script is done running
-console.log("Creating ecosystem.config.js for PM2...");
-let configs = decoder.decode(await Deno.readFile("ecosystem.config.sample.js"));
-configs = configs.replace(/\/path\/to\/website/g, Deno.cwd());
-await Deno.writeFile("./ecosystem.config.js", encoder.encode(configs));
+if (await exists("./ecosystem.config.js") === false) {
+  console.log("Creating ecosystem.config.js for PM2...");
+  let configs = decoder.decode(await Deno.readFile("ecosystem.config.sample.js"));
+  configs = configs.replace(/\/path\/to\/website/g, Deno.cwd());
+  await Deno.writeFile("./ecosystem.config.js", encoder.encode(configs));
+}
 
 await run(["git", "checkout", "main"]);

--- a/console/bumper.ts
+++ b/console/bumper.ts
@@ -1,15 +1,22 @@
-const res = await fetch("https://raw.githubusercontent.com/denoland/deno_website2/master/versions.json");
+const res = await fetch(
+  "https://raw.githubusercontent.com/denoland/deno_website2/master/versions.json",
+);
 const versions: {
-  std: string[],
-  cli: string[],
+  std: string[];
+  cli: string[];
   cli_to_std: {
-    [key: string]: string
-  }
+    [key: string]: string;
+  };
 } = await res.json();
-const latestDenoVersion = versions.cli[0]
-const latestStdVersion = versions.std[0]
-const rawConfigContent = new TextDecoder().decode(Deno.readFileSync("./configs.json"));
+const latestDenoVersion = versions.cli[0];
+const latestStdVersion = versions.std[0];
+const rawConfigContent = new TextDecoder().decode(
+  Deno.readFileSync("./configs.json"),
+);
 const config = JSON.parse(rawConfigContent);
-config.deno.latest_version = latestDenoVersion
-config.deno_std.latest_version = latestStdVersion
-Deno.writeFileSync("./configs.json", new TextEncoder().encode(JSON.stringify(config, null, 2)));
+config.deno.latest_version = latestDenoVersion;
+config.deno_std.latest_version = latestStdVersion;
+Deno.writeFileSync(
+  "./configs.json",
+  new TextEncoder().encode(JSON.stringify(config, null, 2)),
+);

--- a/console/compile_vue_routes.js
+++ b/console/compile_vue_routes.js
@@ -10,7 +10,8 @@ const outFile = configs.root_directory + "/src/" + moduleName +"/compiled_vue_ro
 
 console.log(`Compiling ${outFile} for ${moduleName}-${moduleVersion}`);
 
-let importString = ``;
+let importString = `// deno-lint-ignore-file
+`;
 let exportString = `
 export default [
 `;

--- a/console/git_pull_all.ts
+++ b/console/git_pull_all.ts
@@ -6,6 +6,6 @@ await gitPullLatest("dmm-v1.x");
 await gitPullLatest("drash-v1.x");
 await gitPullLatest("rhum-v1.x");
 await gitPullLatest("wocket-v0.x");
-await gitPullLatest("sinco-v1.x")
+await gitPullLatest("sinco-v1.x");
 
 await run(["git", "checkout", "main"]);

--- a/console/scripts.ts
+++ b/console/scripts.ts
@@ -5,7 +5,7 @@ const decoder = new TextDecoder();
  *
  * @param parentBranch - One of the parent branches (e.g., rhum-v1.x).
  */
-export async function buildDocs(parentBranch: string = "") {
+export async function buildDocs(parentBranch = "") {
   if (parentBranch != "") {
     await run(["git", "checkout", parentBranch]);
   }
@@ -19,7 +19,9 @@ export async function buildDocs(parentBranch: string = "") {
  */
 export async function gitMergeMainInto(parentBranch: string) {
   await run(["git", "checkout", parentBranch]);
-  await run(["git", "merge", "--no-ff", "main", "-m", "update with main branch"]);
+  await run(
+    ["git", "merge", "--no-ff", "main", "-m", "update with main branch"],
+  );
   await run(["git", "push"]);
 }
 
@@ -44,7 +46,7 @@ export async function run(command: string[]) {
     stderr: "piped",
   });
 
-  const status = await p.status()
+  const status = await p.status();
 
   if (status.code === 1) {
     console.log(decoder.decode(await p.stderrOutput()));

--- a/console/scripts.ts
+++ b/console/scripts.ts
@@ -52,3 +52,19 @@ export async function run(command: string[]) {
 
   p.close();
 }
+
+export const exists = async (filename: string): Promise<boolean> => {
+  try {
+    await Deno.stat(filename);
+    // successful, file or directory must exist
+    return true;
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      // file or directory does not exist
+      return false;
+    } else {
+      // unexpected error, maybe permissions, pass it along
+      throw error;
+    }
+  }
+};

--- a/console/serve_dev.ts
+++ b/console/serve_dev.ts
@@ -5,6 +5,6 @@ const parentBranch = args[0]; // e.g., rhum-v1.x
 
 await run(["node", "console/compile_vue_routes.js", parentBranch]);
 
-await run(["pkill", "-f", "drash_website_server.ts"]);
+await run(["pkill", "-f", "app.ts"]);
 
-await run(["deno", "run", "-A", "drash_website_server.ts"]);
+await run(["deno", "run", "-A", "app.ts"]);

--- a/console/webpack
+++ b/console/webpack
@@ -2,13 +2,22 @@
 
 BRANCH="$(git branch --show-current)"
 PARENT_BRANCH="$1"
+WATCH_IS_SET="$2"
 
 echo -e "Building bundles for $PARENT_BRANCH/$BRANCH"
 
 node console/compile_vue_routes.js $PARENT_BRANCH
 
-node_modules/.bin/webpack \
-  --config ./configs.webpack.development.js \
-  --hide-modules \
-  --env.branch=$PARENT_BRANCH \
-  --watch
+if [ "$WATCH_IS_SET" != "" ]; then
+  node_modules/.bin/webpack \
+    --config ./configs.webpack.development.js \
+    --hide-modules \
+    --env.branch=$PARENT_BRANCH \
+    --watch
+else
+  node_modules/.bin/webpack \
+    --config ./configs.webpack.development.js \
+    --hide-modules \
+    --env.branch=$PARENT_BRANCH \
+    --watch
+fi

--- a/deps.ts
+++ b/deps.ts
@@ -1,4 +1,4 @@
 export const decoder = new TextDecoder();
 export const encoder = new TextEncoder();
-export { Drash } from "https://deno.land/x/drash@v1.3.1/mod.ts"
+export { Drash } from "https://deno.land/x/drash@v1.3.1/mod.ts";
 export { configs } from "./configs.js";

--- a/ecosystem.config.sample.js
+++ b/ecosystem.config.sample.js
@@ -3,7 +3,7 @@ module.exports = {
     {
       cwd: "/path/to/website",
       name: "Drash Land",
-      script: "deno run --allow-net --allow-read ./drash_website_server.ts",
+      script: "deno run --allow-net --allow-read ./app.ts",
       watch: "true",
     },
   ]

--- a/server.ts
+++ b/server.ts
@@ -1,7 +1,6 @@
 import { Drash } from "./deps.ts";
 import { LandingResource } from "./src/resources/landing_resource.ts";
 import { ModuleResource } from "./src/resources/module_resource.ts";
-import { StagingModuleResource } from "./src/resources/staging_module_resource.ts";
 import { Response } from "./src/response.ts";
 
 Drash.Http.Response = Response;
@@ -10,7 +9,6 @@ export const server = new Drash.Http.Server({
   resources: [
     LandingResource,
     ModuleResource,
-    StagingModuleResource,
   ],
   response_output: "text/html",
   static_paths: {

--- a/server.ts
+++ b/server.ts
@@ -6,7 +6,7 @@ import { Response } from "./src/response.ts";
 
 Drash.Http.Response = Response
 
-const server = new Drash.Http.Server({
+export const server = new Drash.Http.Server({
   resources: [
     LandingResource,
     ModuleResource,
@@ -18,10 +18,3 @@ const server = new Drash.Http.Server({
   },
   directory: "."
 })
-
-await server.run({
-  hostname: "localhost",
-  port: 1445
-});
-
-console.log(`Running server on http://${server.hostname}:${server.port}`)

--- a/server.ts
+++ b/server.ts
@@ -4,7 +4,7 @@ import { ModuleResource } from "./src/resources/module_resource.ts";
 import { StagingModuleResource } from "./src/resources/staging_module_resource.ts";
 import { Response } from "./src/response.ts";
 
-Drash.Http.Response = Response
+Drash.Http.Response = Response;
 
 export const server = new Drash.Http.Server({
   resources: [
@@ -16,5 +16,5 @@ export const server = new Drash.Http.Server({
   static_paths: {
     "/assets": "/assets",
   },
-  directory: "."
-})
+  directory: ".",
+});

--- a/src/resources/base_resource.ts
+++ b/src/resources/base_resource.ts
@@ -4,7 +4,6 @@ import { configs } from "../../deps.ts";
 const decoder = new TextDecoder();
 
 export class BaseResource extends Drash.Http.Resource {
-
   /**
    * A list of recognized modules that users can access pages for. If a user
    * tries to access a page for a module that isn't in this list, then an error
@@ -51,19 +50,19 @@ export class BaseResource extends Drash.Http.Resource {
    * @returns The environment name.
    */
   protected getEnvironment(): string {
-      const host = this.request.headers.get("host") || "";
-      const isRunningOnLiveServer = this.request.headers.get("x-forwarded-host");
-      const isStaging = host.includes("staging");
+    const host = this.request.headers.get("host") || "";
+    const isRunningOnLiveServer = this.request.headers.get("x-forwarded-host");
+    const isStaging = host.includes("staging");
 
-      if (isStaging) {
-        return "staging";
-      }
+    if (isStaging) {
+      return "staging";
+    }
 
-      if (isRunningOnLiveServer) {
-        return "production";
-      }
+    if (isRunningOnLiveServer) {
+      return "production";
+    }
 
-      return "development";
+    return "development";
   }
 
   /**
@@ -101,12 +100,18 @@ export class BaseResource extends Drash.Http.Resource {
    *
    * @returns The repsonse object.
    */
-  protected sendDocsPage(moduleName: string, version: string = ""): Drash.Http.Response {
+  protected sendDocsPage(
+    moduleName: string,
+    version: string = "",
+  ): Drash.Http.Response {
     this.response.body = decoder.decode(Deno.readFileSync("./src/module.html"))
       .replace("{{ title }}", "Drash Land - " + this.ucfirst(moduleName))
       .replace(/\{\{ module \}\}/g, moduleName)
       .replace("{{ drash_api_configs }}", this.getServerConfigs());
-      this.response.body = this.response.body.replace(/\{\{ version \}\}/g, version)
+    this.response.body = this.response.body.replace(
+      /\{\{ version \}\}/g,
+      version,
+    );
     return this.response;
   }
 
@@ -139,7 +144,7 @@ export class BaseResource extends Drash.Http.Resource {
    */
   protected async sendVersionedDocsPage(
     moduleName: string,
-    version: string
+    version: string,
   ): Promise<Drash.Http.Response> {
     let filename = `./assets/bundles/${moduleName}.${version}.js`;
 

--- a/src/resources/base_resource.ts
+++ b/src/resources/base_resource.ts
@@ -73,7 +73,7 @@ export class BaseResource extends Drash.Http.Resource {
    * @returns The configs as stringified JSON.
    */
   protected getServerConfigs(): string {
-    let sanitizedConfigs = configs;
+    const sanitizedConfigs = configs;
     sanitizedConfigs.root_directory = "***";
     return JSON.stringify(Object.assign(sanitizedConfigs, {
       environment: this.getEnvironment(),
@@ -102,7 +102,7 @@ export class BaseResource extends Drash.Http.Resource {
    */
   protected sendDocsPage(
     moduleName: string,
-    version: string = "",
+    version = "",
   ): Drash.Http.Response {
     this.response.body = decoder.decode(Deno.readFileSync("./src/module.html"))
       .replace("{{ title }}", "Drash Land - " + this.ucfirst(moduleName))
@@ -146,7 +146,7 @@ export class BaseResource extends Drash.Http.Resource {
     moduleName: string,
     version: string,
   ): Promise<Drash.Http.Response> {
-    let filename = `./assets/bundles/${moduleName}.${version}.js`;
+    const filename = `./assets/bundles/${moduleName}.${version}.js`;
 
     this.log(`Getting Vue app: ${filename}`);
 

--- a/src/resources/landing_resource.ts
+++ b/src/resources/landing_resource.ts
@@ -5,13 +5,13 @@ const decoder = new TextDecoder();
 export class LandingResource extends BaseResource {
   static paths = [
     "/",
-  ]
+  ];
 
   //////////////////////////////////////////////////////////////////////////////
   // FILE MARKER - METHODS - HTTP //////////////////////////////////////////////
   //////////////////////////////////////////////////////////////////////////////
 
-  public async GET () {
+  public async GET() {
     this.log("Requested landing page.");
 
     const filename = "./src/landing.html";
@@ -27,13 +27,13 @@ export class LandingResource extends BaseResource {
         ? ` [${environment}]`
         : "";
       content = content
-          .replace("{{ environment }}", environment) // TODO(any): I believe this is dead code - there is no `{{ environment }}` in `landing.html`
-          .replace("{{ title }}", "Drash Land" + titleSuffix)
-          .replace("{{ drash_api_configs }}", this.getServerConfigs());
+        .replace("{{ environment }}", environment) // TODO(any): I believe this is dead code - there is no `{{ environment }}` in `landing.html`
+        .replace("{{ title }}", "Drash Land" + titleSuffix)
+        .replace("{{ drash_api_configs }}", this.getServerConfigs());
 
       this.response.body = content;
 
-      return this.response
+      return this.response;
     } catch (error) {
       this.log(error.stack);
       this.response.body = error;

--- a/src/resources/landing_resource.ts
+++ b/src/resources/landing_resource.ts
@@ -27,7 +27,7 @@ export class LandingResource extends BaseResource {
         ? ` [${environment}]`
         : "";
       content = content
-          .replace("{{ environment }}", environment)
+          .replace("{{ environment }}", environment) // TODO(any): I believe this is dead code - there is no `{{ environment }}` in `landing.html`
           .replace("{{ title }}", "Drash Land" + titleSuffix)
           .replace("{{ drash_api_configs }}", this.getServerConfigs());
 

--- a/src/resources/module_resource.ts
+++ b/src/resources/module_resource.ts
@@ -2,10 +2,9 @@ import { BaseResource } from "./base_resource.ts";
 import { configs } from "../../deps.ts";
 
 export class ModuleResource extends BaseResource {
-
   static paths = [
     "/:module/:version?",
-  ]
+  ];
 
   //////////////////////////////////////////////////////////////////////////////
   // FILE MARKER - METHODS - HTTP //////////////////////////////////////////////
@@ -33,4 +32,3 @@ export class ModuleResource extends BaseResource {
     return this.response.redirect(302, `/${moduleName}/${version}/`);
   }
 }
-

--- a/src/resources/staging_module_resource.ts
+++ b/src/resources/staging_module_resource.ts
@@ -31,7 +31,7 @@ export class StagingModuleResource extends BaseResource {
 
     // @ts-ignore (crookse) We ignore this because we can't use a dynami
     // variable to index the configs which are not typed.
-    version = configs[moduleName].latest_version;
+    version = configs[moduleName].latest_version.split(".")[0] + ".x";
 
     return this.response.redirect(302, `/${moduleName}/${version}/`);
   }

--- a/src/resources/staging_module_resource.ts
+++ b/src/resources/staging_module_resource.ts
@@ -1,6 +1,8 @@
 import { BaseResource } from "./base_resource.ts";
 import { configs } from "../../deps.ts";
 
+// TODO(any) The get method is the same as the module resource, make both use a single function to avoid duplication
+
 export class StagingModuleResource extends BaseResource {
 
   static paths = [

--- a/src/resources/staging_module_resource.ts
+++ b/src/resources/staging_module_resource.ts
@@ -4,10 +4,9 @@ import { configs } from "../../deps.ts";
 // TODO(any) The get method is the same as the module resource, make both use a single function to avoid duplication
 
 export class StagingModuleResource extends BaseResource {
-
   static paths = [
     "/staging/:module/:version?",
-  ]
+  ];
 
   //////////////////////////////////////////////////////////////////////////////
   // FILE MARKER - METHODS - HTTP //////////////////////////////////////////////
@@ -37,4 +36,3 @@ export class StagingModuleResource extends BaseResource {
     return this.response.redirect(302, `/${moduleName}/${version}/`);
   }
 }
-

--- a/src/response.ts
+++ b/src/response.ts
@@ -1,21 +1,22 @@
-import { Drash } from "../deps.ts"
+import { Drash } from "../deps.ts";
 
-const decoder = new TextDecoder()
+const decoder = new TextDecoder();
 
 export class Response extends Drash.Http.Response {
-
   protected error_codes: number[] = [
     400,
     401,
     403,
     404,
-    500
+    500,
   ];
 
-  public generateResponse (): string {
+  public generateResponse(): string {
     if (this.error_codes.indexOf(this.status_code) != -1) {
       try {
-        this.body = decoder.decode(Deno.readFileSync(`./src/Error${this.status_code}.html`));
+        this.body = decoder.decode(
+          Deno.readFileSync(`./src/Error${this.status_code}.html`),
+        );
       } catch (error) {
         console.log(error);
       }
@@ -25,6 +26,6 @@ export class Response extends Drash.Http.Response {
       this.body = decoder.decode(Deno.readFileSync(`./src/Error400.html`));
     }
 
-    return this.body as string
+    return this.body as string;
   }
 }

--- a/tests/integration/deps.ts
+++ b/tests/integration/deps.ts
@@ -1,1 +1,1 @@
-export { Rhum } from  "https://deno.land/x/rhum@v1.1.6/mod.ts"
+export { Rhum } from "https://deno.land/x/rhum@v1.1.6/mod.ts";

--- a/tests/integration/deps.ts
+++ b/tests/integration/deps.ts
@@ -1,0 +1,1 @@
+export { Rhum } from  "https://deno.land/x/rhum@v1.1.6/mod.ts"

--- a/tests/integration/landing_resource_test.ts
+++ b/tests/integration/landing_resource_test.ts
@@ -42,3 +42,5 @@ Rhum.testPlan("tests/integration/landing_resource_test.ts", () => {
     })
   })
 })
+
+Rhum.run()

--- a/tests/integration/landing_resource_test.ts
+++ b/tests/integration/landing_resource_test.ts
@@ -1,46 +1,46 @@
 import { server } from "../../server.ts";
-import {Rhum} from "./deps.ts";
+import { Rhum } from "./deps.ts";
 
 const serverConfigs = {
   hostname: "localhost",
-  port: 1447
-}
-const url = `http://${serverConfigs.hostname}:${serverConfigs.port}`
+  port: 1447,
+};
+const url = `http://${serverConfigs.hostname}:${serverConfigs.port}`;
 
 Rhum.testPlan("tests/integration/landing_resource_test.ts", () => {
   Rhum.testSuite("GET /", () => {
     Rhum.testCase("Responds with a 200 on request", async () => {
-      await server.run(serverConfigs)
+      await server.run(serverConfigs);
       // Development
-      const res = await fetch(url)
-      Rhum.asserts.assertEquals(res.status, 200)
-      const text = await res.text()
-      const title = text.split("<title>")[1].split("</title>")[0]
-      Rhum.asserts.assertEquals(title, "Drash Land [development]")
+      const res = await fetch(url);
+      Rhum.asserts.assertEquals(res.status, 200);
+      const text = await res.text();
+      const title = text.split("<title>")[1].split("</title>")[0];
+      Rhum.asserts.assertEquals(title, "Drash Land [development]");
       // Staging
-      const res2  = await fetch(url, {
+      const res2 = await fetch(url, {
         headers: {
-          "host": "staging"
-        }
-      })
-      Rhum.asserts.assertEquals(res2.status, 200)
-      const text2 = await res2.text()
-      const title2 = text2.split("<title>")[1].split("</title>")[0]
-      Rhum.asserts.assertEquals(title2, "Drash Land [staging]")
+          "host": "staging",
+        },
+      });
+      Rhum.asserts.assertEquals(res2.status, 200);
+      const text2 = await res2.text();
+      const title2 = text2.split("<title>")[1].split("</title>")[0];
+      Rhum.asserts.assertEquals(title2, "Drash Land [staging]");
       // Prod
-      const res3  = await fetch(url, {
+      const res3 = await fetch(url, {
         headers: {
-          "x-forwarded-host": "Blah blah blah"
-        }
-      })
-      Rhum.asserts.assertEquals(res3.status, 200)
-      const text3 = await res3.text()
-      const title3 = text3.split("<title>")[1].split("</title>")[0]
-      Rhum.asserts.assertEquals(title3, "Drash Land")
+          "x-forwarded-host": "Blah blah blah",
+        },
+      });
+      Rhum.asserts.assertEquals(res3.status, 200);
+      const text3 = await res3.text();
+      const title3 = text3.split("<title>")[1].split("</title>")[0];
+      Rhum.asserts.assertEquals(title3, "Drash Land");
 
-      server.close()
-    })
-  })
-})
+      server.close();
+    });
+  });
+});
 
-Rhum.run()
+Rhum.run();

--- a/tests/integration/landing_resource_test.ts
+++ b/tests/integration/landing_resource_test.ts
@@ -1,0 +1,44 @@
+import { server } from "../../server.ts";
+import {Rhum} from "./deps.ts";
+
+const serverConfigs = {
+  hostname: "localhost",
+  port: 1447
+}
+const url = `http://${serverConfigs.hostname}:${serverConfigs.port}`
+
+Rhum.testPlan("tests/integration/landing_resource_test.ts", () => {
+  Rhum.testSuite("GET /", () => {
+    Rhum.testCase("Responds with a 200 on request", async () => {
+      await server.run(serverConfigs)
+      // Development
+      const res = await fetch(url)
+      Rhum.asserts.assertEquals(res.status, 200)
+      const text = await res.text()
+      const title = text.split("<title>")[1].split("</title>")[0]
+      Rhum.asserts.assertEquals(title, "Drash Land [development]")
+      // Staging
+      const res2  = await fetch(url, {
+        headers: {
+          "host": "staging"
+        }
+      })
+      Rhum.asserts.assertEquals(res2.status, 200)
+      const text2 = await res2.text()
+      const title2 = text2.split("<title>")[1].split("</title>")[0]
+      Rhum.asserts.assertEquals(title2, "Drash Land [staging]")
+      // Prod
+      const res3  = await fetch(url, {
+        headers: {
+          "x-forwarded-host": "Blah blah blah"
+        }
+      })
+      Rhum.asserts.assertEquals(res3.status, 200)
+      const text3 = await res3.text()
+      const title3 = text3.split("<title>")[1].split("</title>")[0]
+      Rhum.asserts.assertEquals(title3, "Drash Land")
+
+      server.close()
+    })
+  })
+})

--- a/tests/integration/module_resource_test.ts
+++ b/tests/integration/module_resource_test.ts
@@ -8,48 +8,54 @@ const serverConfigs = {
 const url = `http://${serverConfigs.hostname}:${serverConfigs.port}`
 
 Rhum.testPlan("tests/integration/module_resource_test.ts", () => {
-  Rhum.testSuite("GET /:module", () => {
+  Rhum.testSuite("GET /:module (should redirect back to the module resource with the version set as the latest version)", () => {
     Rhum.testCase("Responds with 302 and redirects to latest version when `module` is drash", async () => {
       await server.run(serverConfigs)
       const res = await fetch(`${url}/drash`)
+      await res.text()
       server.close()
-      Rhum.asserts.assertEquals(res.status, 302)
-      Rhum.asserts.assertEquals(res.url, `${url}/drash/v1.x`)
+      Rhum.asserts.assertEquals(res.status, 200)
+      Rhum.asserts.assertEquals(res.url, `${url}/drash/v1.x/`)
     })
     Rhum.testCase("Responds with 302 redirects to latest version when `module` is dmm", async () => {
       await server.run(serverConfigs)
       const res = await fetch(`${url}/dmm`)
+      await res.text()
       server.close()
-      Rhum.asserts.assertEquals(res.status, 302)
-      Rhum.asserts.assertEquals(res.url, `${url}/dmm/v1.x`)
+      Rhum.asserts.assertEquals(res.status, 200)
+      Rhum.asserts.assertEquals(res.url, `${url}/dmm/v1.x/`)
     })
     Rhum.testCase("Responds with 302 redirects to latest version when `module` is rhum", async () => {
       await server.run(serverConfigs)
       const res = await fetch(`${url}/rhum`)
+      await res.text()
       server.close()
-      Rhum.asserts.assertEquals(res.status, 302)
-      Rhum.asserts.assertEquals(res.url, `${url}/rhum/v1.x`)
+      Rhum.asserts.assertEquals(res.status, 200)
+      Rhum.asserts.assertEquals(res.url, `${url}/rhum/v1.x/`)
     })
     Rhum.testCase("Responds with 302 redirects to latest version when `module` is wocket", async () => {
       await server.run(serverConfigs)
       const res = await fetch(`${url}/wocket`)
+      await res.text()
       server.close()
-      Rhum.asserts.assertEquals(res.status, 302)
-      Rhum.asserts.assertEquals(res.url, `${url}/wocket/v0.x`)
+      Rhum.asserts.assertEquals(res.status, 200)
+      Rhum.asserts.assertEquals(res.url, `${url}/wocket/v0.x/`)
     })
     Rhum.testCase("Responds with 302 redirects to latest version when `module` is sinco", async () => {
       await server.run(serverConfigs)
       const res = await fetch(`${url}/sinco`)
+      await res.text()
       server.close()
-      Rhum.asserts.assertEquals(res.status, 302)
-      Rhum.asserts.assertEquals(res.url, `${url}/sinco/v1.x`)
+      Rhum.asserts.assertEquals(res.status, 200)
+      Rhum.asserts.assertEquals(res.url, `${url}/sinco/v1.x/`)
     })
     Rhum.testCase("Responds with 404 when `module` is not a recognised module", async () => {
       await server.run(serverConfigs)
       const res = await fetch(`${url}/hella`)
+      await res.text()
       server.close()
       Rhum.asserts.assertEquals(res.status, 404)
-      Rhum.asserts.assertEquals(res.url, `${url}/v1.x`) // fixme this will be wrong
+      Rhum.asserts.assertEquals(res.url, `${url}/hella`)
     })
   })
   Rhum.testSuite("GET /:module/:version", () => {
@@ -94,7 +100,7 @@ Rhum.testPlan("tests/integration/module_resource_test.ts", () => {
     Rhum.testCase("Responds with 200 for /wocket/v0.x", async () => {
       await server.run(serverConfigs)
       const res = await fetch(`${url}/wocket/v0.x`)
-      Rhum.asserts.assertEquals(res.status, 302)
+      Rhum.asserts.assertEquals(res.status, 200)
       Rhum.asserts.assertEquals(res.url, `${url}/wocket/v0.x`)
       const text = await res.text()
       server.close()
@@ -105,8 +111,8 @@ Rhum.testPlan("tests/integration/module_resource_test.ts", () => {
     })
     Rhum.testCase("Responds with 200 for /sinco/v1.x", async () => {
       await server.run(serverConfigs)
-      const res = await fetch(`${url}/sinco`)
-      Rhum.asserts.assertEquals(res.status, 302)
+      const res = await fetch(`${url}/sinco/v1.x`)
+      Rhum.asserts.assertEquals(res.status, 200)
       Rhum.asserts.assertEquals(res.url, `${url}/sinco/v1.x`)
       const text = await res.text()
       server.close()
@@ -118,9 +124,12 @@ Rhum.testPlan("tests/integration/module_resource_test.ts", () => {
     Rhum.testCase("Responds with 404 when `version` is not a recognised version for the module", async () => {
       await server.run(serverConfigs)
       const res = await fetch(`${url}/drash/hella`)
+      await res.text()
       server.close()
       Rhum.asserts.assertEquals(res.status, 404)
-      Rhum.asserts.assertEquals(res.url, `${url}/v1.x`) // fixme this will be wrong
+      Rhum.asserts.assertEquals(res.url, `${url}/drash/hella`)
     })
   })
 })
+
+Rhum.run()

--- a/tests/integration/module_resource_test.ts
+++ b/tests/integration/module_resource_test.ts
@@ -1,135 +1,169 @@
 import { server } from "../../server.ts";
-import {Rhum} from "./deps.ts";
+import { Rhum } from "./deps.ts";
 
 const serverConfigs = {
   hostname: "localhost",
-  port: 1447
-}
-const url = `http://${serverConfigs.hostname}:${serverConfigs.port}`
+  port: 1447,
+};
+const url = `http://${serverConfigs.hostname}:${serverConfigs.port}`;
 
 Rhum.testPlan("tests/integration/module_resource_test.ts", () => {
-  Rhum.testSuite("GET /:module (should redirect back to the module resource with the version set as the latest version)", () => {
-    Rhum.testCase("Responds with 302 and redirects to latest version when `module` is drash", async () => {
-      await server.run(serverConfigs)
-      const res = await fetch(`${url}/drash`)
-      await res.text()
-      server.close()
-      Rhum.asserts.assertEquals(res.status, 200)
-      Rhum.asserts.assertEquals(res.url, `${url}/drash/v1.x/`)
-    })
-    Rhum.testCase("Responds with 302 redirects to latest version when `module` is dmm", async () => {
-      await server.run(serverConfigs)
-      const res = await fetch(`${url}/dmm`)
-      await res.text()
-      server.close()
-      Rhum.asserts.assertEquals(res.status, 200)
-      Rhum.asserts.assertEquals(res.url, `${url}/dmm/v1.x/`)
-    })
-    Rhum.testCase("Responds with 302 redirects to latest version when `module` is rhum", async () => {
-      await server.run(serverConfigs)
-      const res = await fetch(`${url}/rhum`)
-      await res.text()
-      server.close()
-      Rhum.asserts.assertEquals(res.status, 200)
-      Rhum.asserts.assertEquals(res.url, `${url}/rhum/v1.x/`)
-    })
-    Rhum.testCase("Responds with 302 redirects to latest version when `module` is wocket", async () => {
-      await server.run(serverConfigs)
-      const res = await fetch(`${url}/wocket`)
-      await res.text()
-      server.close()
-      Rhum.asserts.assertEquals(res.status, 200)
-      Rhum.asserts.assertEquals(res.url, `${url}/wocket/v0.x/`)
-    })
-    Rhum.testCase("Responds with 302 redirects to latest version when `module` is sinco", async () => {
-      await server.run(serverConfigs)
-      const res = await fetch(`${url}/sinco`)
-      await res.text()
-      server.close()
-      Rhum.asserts.assertEquals(res.status, 200)
-      Rhum.asserts.assertEquals(res.url, `${url}/sinco/v1.x/`)
-    })
-    Rhum.testCase("Responds with 404 when `module` is not a recognised module", async () => {
-      await server.run(serverConfigs)
-      const res = await fetch(`${url}/hella`)
-      await res.text()
-      server.close()
-      Rhum.asserts.assertEquals(res.status, 404)
-      Rhum.asserts.assertEquals(res.url, `${url}/hella`)
-    })
-  })
+  Rhum.testSuite(
+    "GET /:module (should redirect back to the module resource with the version set as the latest version)",
+    () => {
+      Rhum.testCase(
+        "Responds with 302 and redirects to latest version when `module` is drash",
+        async () => {
+          await server.run(serverConfigs);
+          const res = await fetch(`${url}/drash`);
+          await res.text();
+          server.close();
+          Rhum.asserts.assertEquals(res.status, 200);
+          Rhum.asserts.assertEquals(res.url, `${url}/drash/v1.x/`);
+        },
+      );
+      Rhum.testCase(
+        "Responds with 302 redirects to latest version when `module` is dmm",
+        async () => {
+          await server.run(serverConfigs);
+          const res = await fetch(`${url}/dmm`);
+          await res.text();
+          server.close();
+          Rhum.asserts.assertEquals(res.status, 200);
+          Rhum.asserts.assertEquals(res.url, `${url}/dmm/v1.x/`);
+        },
+      );
+      Rhum.testCase(
+        "Responds with 302 redirects to latest version when `module` is rhum",
+        async () => {
+          await server.run(serverConfigs);
+          const res = await fetch(`${url}/rhum`);
+          await res.text();
+          server.close();
+          Rhum.asserts.assertEquals(res.status, 200);
+          Rhum.asserts.assertEquals(res.url, `${url}/rhum/v1.x/`);
+        },
+      );
+      Rhum.testCase(
+        "Responds with 302 redirects to latest version when `module` is wocket",
+        async () => {
+          await server.run(serverConfigs);
+          const res = await fetch(`${url}/wocket`);
+          await res.text();
+          server.close();
+          Rhum.asserts.assertEquals(res.status, 200);
+          Rhum.asserts.assertEquals(res.url, `${url}/wocket/v0.x/`);
+        },
+      );
+      Rhum.testCase(
+        "Responds with 302 redirects to latest version when `module` is sinco",
+        async () => {
+          await server.run(serverConfigs);
+          const res = await fetch(`${url}/sinco`);
+          await res.text();
+          server.close();
+          Rhum.asserts.assertEquals(res.status, 200);
+          Rhum.asserts.assertEquals(res.url, `${url}/sinco/v1.x/`);
+        },
+      );
+      Rhum.testCase(
+        "Responds with 404 when `module` is not a recognised module",
+        async () => {
+          await server.run(serverConfigs);
+          const res = await fetch(`${url}/hella`);
+          await res.text();
+          server.close();
+          Rhum.asserts.assertEquals(res.status, 404);
+          Rhum.asserts.assertEquals(res.url, `${url}/hella`);
+        },
+      );
+    },
+  );
   Rhum.testSuite("GET /:module/:version", () => {
     Rhum.testCase("Responds with 200 for /drash/v1.x", async () => {
-      await server.run(serverConfigs)
+      await server.run(serverConfigs);
       // Development
-      const res = await fetch(`${url}/drash/v1.x`)
-      Rhum.asserts.assertEquals(res.status, 200)
-      Rhum.asserts.assertEquals(res.url, `${url}/drash/v1.x`)
-      const text = await res.text()
-      server.close()
-      const title = text.split("<title>")[1].split("</title>")[0]
-      Rhum.asserts.assertEquals(title, "Drash Land - Drash")
-      const bundle = text.includes(`<script src="/assets/bundles/drash.v1.x.js"></script>`)
-      Rhum.asserts.assertEquals(bundle, true)
-    })
+      const res = await fetch(`${url}/drash/v1.x`);
+      Rhum.asserts.assertEquals(res.status, 200);
+      Rhum.asserts.assertEquals(res.url, `${url}/drash/v1.x`);
+      const text = await res.text();
+      server.close();
+      const title = text.split("<title>")[1].split("</title>")[0];
+      Rhum.asserts.assertEquals(title, "Drash Land - Drash");
+      const bundle = text.includes(
+        `<script src="/assets/bundles/drash.v1.x.js"></script>`,
+      );
+      Rhum.asserts.assertEquals(bundle, true);
+    });
     Rhum.testCase("Responds with 200 for /dmm/v1.x", async () => {
-      await server.run(serverConfigs)
+      await server.run(serverConfigs);
       // Development
-      const res = await fetch(`${url}/dmm/v1.x`)
-      Rhum.asserts.assertEquals(res.status, 200)
-      Rhum.asserts.assertEquals(res.url, `${url}/dmm/v1.x`)
-      const text = await res.text()
-      server.close()
-      const title = text.split("<title>")[1].split("</title>")[0]
-      Rhum.asserts.assertEquals(title, "Drash Land - Dmm")
-      const bundle = text.includes(`<script src="/assets/bundles/dmm.v1.x.js"></script>`)
-      Rhum.asserts.assertEquals(bundle, true)
-    })
+      const res = await fetch(`${url}/dmm/v1.x`);
+      Rhum.asserts.assertEquals(res.status, 200);
+      Rhum.asserts.assertEquals(res.url, `${url}/dmm/v1.x`);
+      const text = await res.text();
+      server.close();
+      const title = text.split("<title>")[1].split("</title>")[0];
+      Rhum.asserts.assertEquals(title, "Drash Land - Dmm");
+      const bundle = text.includes(
+        `<script src="/assets/bundles/dmm.v1.x.js"></script>`,
+      );
+      Rhum.asserts.assertEquals(bundle, true);
+    });
     Rhum.testCase("Responds with 200 for /rhum/v1.x", async () => {
-      await server.run(serverConfigs)
-      const res = await fetch(`${url}/rhum/v1.x`)
-      Rhum.asserts.assertEquals(res.status, 200)
-      Rhum.asserts.assertEquals(res.url, `${url}/rhum/v1.x`)
-      const text = await res.text()
-      server.close()
-      const title = text.split("<title>")[1].split("</title>")[0]
-      Rhum.asserts.assertEquals(title, "Drash Land - Rhum")
-      const bundle = text.includes(`<script src="/assets/bundles/rhum.v1.x.js"></script>`)
-      Rhum.asserts.assertEquals(bundle, true)
-    })
+      await server.run(serverConfigs);
+      const res = await fetch(`${url}/rhum/v1.x`);
+      Rhum.asserts.assertEquals(res.status, 200);
+      Rhum.asserts.assertEquals(res.url, `${url}/rhum/v1.x`);
+      const text = await res.text();
+      server.close();
+      const title = text.split("<title>")[1].split("</title>")[0];
+      Rhum.asserts.assertEquals(title, "Drash Land - Rhum");
+      const bundle = text.includes(
+        `<script src="/assets/bundles/rhum.v1.x.js"></script>`,
+      );
+      Rhum.asserts.assertEquals(bundle, true);
+    });
     Rhum.testCase("Responds with 200 for /wocket/v0.x", async () => {
-      await server.run(serverConfigs)
-      const res = await fetch(`${url}/wocket/v0.x`)
-      Rhum.asserts.assertEquals(res.status, 200)
-      Rhum.asserts.assertEquals(res.url, `${url}/wocket/v0.x`)
-      const text = await res.text()
-      server.close()
-      const title = text.split("<title>")[1].split("</title>")[0]
-      Rhum.asserts.assertEquals(title, "Drash Land - Wocket")
-      const bundle = text.includes(`<script src="/assets/bundles/wocket.v0.x.js"></script>`)
-      Rhum.asserts.assertEquals(bundle, true)
-    })
+      await server.run(serverConfigs);
+      const res = await fetch(`${url}/wocket/v0.x`);
+      Rhum.asserts.assertEquals(res.status, 200);
+      Rhum.asserts.assertEquals(res.url, `${url}/wocket/v0.x`);
+      const text = await res.text();
+      server.close();
+      const title = text.split("<title>")[1].split("</title>")[0];
+      Rhum.asserts.assertEquals(title, "Drash Land - Wocket");
+      const bundle = text.includes(
+        `<script src="/assets/bundles/wocket.v0.x.js"></script>`,
+      );
+      Rhum.asserts.assertEquals(bundle, true);
+    });
     Rhum.testCase("Responds with 200 for /sinco/v1.x", async () => {
-      await server.run(serverConfigs)
-      const res = await fetch(`${url}/sinco/v1.x`)
-      Rhum.asserts.assertEquals(res.status, 200)
-      Rhum.asserts.assertEquals(res.url, `${url}/sinco/v1.x`)
-      const text = await res.text()
-      server.close()
-      const title = text.split("<title>")[1].split("</title>")[0]
-      Rhum.asserts.assertEquals(title, "Drash Land - Sinco")
-      const bundle = text.includes(`<script src="/assets/bundles/sinco.v1.x.js"></script>`)
-      Rhum.asserts.assertEquals(bundle, true)
-    })
-    Rhum.testCase("Responds with 404 when `version` is not a recognised version for the module", async () => {
-      await server.run(serverConfigs)
-      const res = await fetch(`${url}/drash/hella`)
-      await res.text()
-      server.close()
-      Rhum.asserts.assertEquals(res.status, 404)
-      Rhum.asserts.assertEquals(res.url, `${url}/drash/hella`)
-    })
-  })
-})
+      await server.run(serverConfigs);
+      const res = await fetch(`${url}/sinco/v1.x`);
+      Rhum.asserts.assertEquals(res.status, 200);
+      Rhum.asserts.assertEquals(res.url, `${url}/sinco/v1.x`);
+      const text = await res.text();
+      server.close();
+      const title = text.split("<title>")[1].split("</title>")[0];
+      Rhum.asserts.assertEquals(title, "Drash Land - Sinco");
+      const bundle = text.includes(
+        `<script src="/assets/bundles/sinco.v1.x.js"></script>`,
+      );
+      Rhum.asserts.assertEquals(bundle, true);
+    });
+    Rhum.testCase(
+      "Responds with 404 when `version` is not a recognised version for the module",
+      async () => {
+        await server.run(serverConfigs);
+        const res = await fetch(`${url}/drash/hella`);
+        await res.text();
+        server.close();
+        Rhum.asserts.assertEquals(res.status, 404);
+        Rhum.asserts.assertEquals(res.url, `${url}/drash/hella`);
+      },
+    );
+  });
+});
 
-Rhum.run()
+Rhum.run();

--- a/tests/integration/module_resource_test.ts
+++ b/tests/integration/module_resource_test.ts
@@ -1,0 +1,126 @@
+import { server } from "../../server.ts";
+import {Rhum} from "./deps.ts";
+
+const serverConfigs = {
+  hostname: "localhost",
+  port: 1447
+}
+const url = `http://${serverConfigs.hostname}:${serverConfigs.port}`
+
+Rhum.testPlan("tests/integration/module_resource_test.ts", () => {
+  Rhum.testSuite("GET /:module", () => {
+    Rhum.testCase("Responds with 302 and redirects to latest version when `module` is drash", async () => {
+      await server.run(serverConfigs)
+      const res = await fetch(`${url}/drash`)
+      server.close()
+      Rhum.asserts.assertEquals(res.status, 302)
+      Rhum.asserts.assertEquals(res.url, `${url}/drash/v1.x`)
+    })
+    Rhum.testCase("Responds with 302 redirects to latest version when `module` is dmm", async () => {
+      await server.run(serverConfigs)
+      const res = await fetch(`${url}/dmm`)
+      server.close()
+      Rhum.asserts.assertEquals(res.status, 302)
+      Rhum.asserts.assertEquals(res.url, `${url}/dmm/v1.x`)
+    })
+    Rhum.testCase("Responds with 302 redirects to latest version when `module` is rhum", async () => {
+      await server.run(serverConfigs)
+      const res = await fetch(`${url}/rhum`)
+      server.close()
+      Rhum.asserts.assertEquals(res.status, 302)
+      Rhum.asserts.assertEquals(res.url, `${url}/rhum/v1.x`)
+    })
+    Rhum.testCase("Responds with 302 redirects to latest version when `module` is wocket", async () => {
+      await server.run(serverConfigs)
+      const res = await fetch(`${url}/wocket`)
+      server.close()
+      Rhum.asserts.assertEquals(res.status, 302)
+      Rhum.asserts.assertEquals(res.url, `${url}/wocket/v0.x`)
+    })
+    Rhum.testCase("Responds with 302 redirects to latest version when `module` is sinco", async () => {
+      await server.run(serverConfigs)
+      const res = await fetch(`${url}/sinco`)
+      server.close()
+      Rhum.asserts.assertEquals(res.status, 302)
+      Rhum.asserts.assertEquals(res.url, `${url}/sinco/v1.x`)
+    })
+    Rhum.testCase("Responds with 404 when `module` is not a recognised module", async () => {
+      await server.run(serverConfigs)
+      const res = await fetch(`${url}/hella`)
+      server.close()
+      Rhum.asserts.assertEquals(res.status, 404)
+      Rhum.asserts.assertEquals(res.url, `${url}/v1.x`) // fixme this will be wrong
+    })
+  })
+  Rhum.testSuite("GET /:module/:version", () => {
+    Rhum.testCase("Responds with 200 for /drash/v1.x", async () => {
+      await server.run(serverConfigs)
+      // Development
+      const res = await fetch(`${url}/drash/v1.x`)
+      Rhum.asserts.assertEquals(res.status, 200)
+      Rhum.asserts.assertEquals(res.url, `${url}/drash/v1.x`)
+      const text = await res.text()
+      server.close()
+      const title = text.split("<title>")[1].split("</title>")[0]
+      Rhum.asserts.assertEquals(title, "Drash Land - Drash")
+      const bundle = text.includes(`<script src="/assets/bundles/drash.v1.x.js"></script>`)
+      Rhum.asserts.assertEquals(bundle, true)
+    })
+    Rhum.testCase("Responds with 200 for /dmm/v1.x", async () => {
+      await server.run(serverConfigs)
+      // Development
+      const res = await fetch(`${url}/dmm/v1.x`)
+      Rhum.asserts.assertEquals(res.status, 200)
+      Rhum.asserts.assertEquals(res.url, `${url}/dmm/v1.x`)
+      const text = await res.text()
+      server.close()
+      const title = text.split("<title>")[1].split("</title>")[0]
+      Rhum.asserts.assertEquals(title, "Drash Land - Dmm")
+      const bundle = text.includes(`<script src="/assets/bundles/dmm.v1.x.js"></script>`)
+      Rhum.asserts.assertEquals(bundle, true)
+    })
+    Rhum.testCase("Responds with 200 for /rhum/v1.x", async () => {
+      await server.run(serverConfigs)
+      const res = await fetch(`${url}/rhum/v1.x`)
+      Rhum.asserts.assertEquals(res.status, 200)
+      Rhum.asserts.assertEquals(res.url, `${url}/rhum/v1.x`)
+      const text = await res.text()
+      server.close()
+      const title = text.split("<title>")[1].split("</title>")[0]
+      Rhum.asserts.assertEquals(title, "Drash Land - Rhum")
+      const bundle = text.includes(`<script src="/assets/bundles/rhum.v1.x.js"></script>`)
+      Rhum.asserts.assertEquals(bundle, true)
+    })
+    Rhum.testCase("Responds with 200 for /wocket/v0.x", async () => {
+      await server.run(serverConfigs)
+      const res = await fetch(`${url}/wocket/v0.x`)
+      Rhum.asserts.assertEquals(res.status, 302)
+      Rhum.asserts.assertEquals(res.url, `${url}/wocket/v0.x`)
+      const text = await res.text()
+      server.close()
+      const title = text.split("<title>")[1].split("</title>")[0]
+      Rhum.asserts.assertEquals(title, "Drash Land - Wocket")
+      const bundle = text.includes(`<script src="/assets/bundles/wocket.v0.x.js"></script>`)
+      Rhum.asserts.assertEquals(bundle, true)
+    })
+    Rhum.testCase("Responds with 200 for /sinco/v1.x", async () => {
+      await server.run(serverConfigs)
+      const res = await fetch(`${url}/sinco`)
+      Rhum.asserts.assertEquals(res.status, 302)
+      Rhum.asserts.assertEquals(res.url, `${url}/sinco/v1.x`)
+      const text = await res.text()
+      server.close()
+      const title = text.split("<title>")[1].split("</title>")[0]
+      Rhum.asserts.assertEquals(title, "Drash Land - Sinco")
+      const bundle = text.includes(`<script src="/assets/bundles/sinco.v1.x.js"></script>`)
+      Rhum.asserts.assertEquals(bundle, true)
+    })
+    Rhum.testCase("Responds with 404 when `version` is not a recognised version for the module", async () => {
+      await server.run(serverConfigs)
+      const res = await fetch(`${url}/drash/hella`)
+      server.close()
+      Rhum.asserts.assertEquals(res.status, 404)
+      Rhum.asserts.assertEquals(res.url, `${url}/v1.x`) // fixme this will be wrong
+    })
+  })
+})

--- a/tests/integration/staging_module_resource_test.ts
+++ b/tests/integration/staging_module_resource_test.ts
@@ -1,128 +1,159 @@
 import { server } from "../../server.ts";
-import {Rhum} from "./deps.ts";
+import { Rhum } from "./deps.ts";
 
 const serverConfigs = {
   hostname: "localhost",
-  port: 1447
-}
-const url = `http://${serverConfigs.hostname}:${serverConfigs.port}/staging`
+  port: 1447,
+};
+const url = `http://${serverConfigs.hostname}:${serverConfigs.port}/staging`;
 
 Rhum.testPlan("tests/integration/staging_module_resource_test.ts", () => {
   Rhum.testSuite("GET /staging/:module", () => {
-    Rhum.testCase("Responds with 302 and redirects to latest version when `module` is drash", async () => {
-      await server.run(serverConfigs)
-      const res = await fetch(`${url}/drash`)
-      server.close()
-      Rhum.asserts.assertEquals(res.status, 302)
-      Rhum.asserts.assertEquals(res.url, `${url}/drash/v1.x`)
-    })
-    Rhum.testCase("Responds with 302 redirects to latest version when `module` is dmm", async () => {
-      await server.run(serverConfigs)
-      const res = await fetch(`${url}/dmm`)
-      server.close()
-      Rhum.asserts.assertEquals(res.status, 302)
-      Rhum.asserts.assertEquals(res.url, `${url}/dmm/v1.x`)
-    })
-    Rhum.testCase("Responds with 302 redirects to latest version when `module` is rhum", async () => {
-      await server.run(serverConfigs)
-      const res = await fetch(`${url}/rhum`)
-      server.close()
-      Rhum.asserts.assertEquals(res.status, 302)
-      Rhum.asserts.assertEquals(res.url, `${url}/rhum/v1.x`)
-    })
-    Rhum.testCase("Responds with 302 redirects to latest version when `module` is wocket", async () => {
-      await server.run(serverConfigs)
-      const res = await fetch(`${url}/wocket`)
-      server.close()
-      Rhum.asserts.assertEquals(res.status, 302)
-      Rhum.asserts.assertEquals(res.url, `${url}/wocket/v0.x`)
-    })
-    Rhum.testCase("Responds with 302 redirects to latest version when `module` is sinco", async () => {
-      await server.run(serverConfigs)
-      const res = await fetch(`${url}/sinco`)
-      server.close()
-      Rhum.asserts.assertEquals(res.status, 302)
-      Rhum.asserts.assertEquals(res.url, `${url}/sinco/v1.x`)
-    })
-    Rhum.testCase("Responds with 404 when `module` is not a recognised module", async () => {
-      await server.run(serverConfigs)
-      const res = await fetch(`${url}/hella`)
-      server.close()
-      Rhum.asserts.assertEquals(res.status, 404)
-      Rhum.asserts.assertEquals(res.url, `${url}/v1.x`) // fixme this will be wrong
-    })
-  })
+    Rhum.testCase(
+      "Responds with 302 and redirects to latest version when `module` is drash",
+      async () => {
+        await server.run(serverConfigs);
+        const res = await fetch(`${url}/drash`);
+        server.close();
+        Rhum.asserts.assertEquals(res.status, 302);
+        Rhum.asserts.assertEquals(res.url, `${url}/drash/v1.x`);
+      },
+    );
+    Rhum.testCase(
+      "Responds with 302 redirects to latest version when `module` is dmm",
+      async () => {
+        await server.run(serverConfigs);
+        const res = await fetch(`${url}/dmm`);
+        server.close();
+        Rhum.asserts.assertEquals(res.status, 302);
+        Rhum.asserts.assertEquals(res.url, `${url}/dmm/v1.x`);
+      },
+    );
+    Rhum.testCase(
+      "Responds with 302 redirects to latest version when `module` is rhum",
+      async () => {
+        await server.run(serverConfigs);
+        const res = await fetch(`${url}/rhum`);
+        server.close();
+        Rhum.asserts.assertEquals(res.status, 302);
+        Rhum.asserts.assertEquals(res.url, `${url}/rhum/v1.x`);
+      },
+    );
+    Rhum.testCase(
+      "Responds with 302 redirects to latest version when `module` is wocket",
+      async () => {
+        await server.run(serverConfigs);
+        const res = await fetch(`${url}/wocket`);
+        server.close();
+        Rhum.asserts.assertEquals(res.status, 302);
+        Rhum.asserts.assertEquals(res.url, `${url}/wocket/v0.x`);
+      },
+    );
+    Rhum.testCase(
+      "Responds with 302 redirects to latest version when `module` is sinco",
+      async () => {
+        await server.run(serverConfigs);
+        const res = await fetch(`${url}/sinco`);
+        server.close();
+        Rhum.asserts.assertEquals(res.status, 302);
+        Rhum.asserts.assertEquals(res.url, `${url}/sinco/v1.x`);
+      },
+    );
+    Rhum.testCase(
+      "Responds with 404 when `module` is not a recognised module",
+      async () => {
+        await server.run(serverConfigs);
+        const res = await fetch(`${url}/hella`);
+        server.close();
+        Rhum.asserts.assertEquals(res.status, 404);
+        Rhum.asserts.assertEquals(res.url, `${url}/v1.x`); // fixme this will be wrong
+      },
+    );
+  });
   Rhum.testSuite("GET /staging/:module/:version", () => {
     Rhum.testCase("Responds with 200 for /drash/v1.x", async () => {
-      await server.run(serverConfigs)
+      await server.run(serverConfigs);
       // Development
-      const res = await fetch(`${url}/drash/v1.x`)
-      Rhum.asserts.assertEquals(res.status, 200)
-      Rhum.asserts.assertEquals(res.url, `${url}/drash/v1.x`)
-      const text = await res.text()
-      server.close()
-      const title = text.split("<title>")[1].split("</title>")[0]
-      Rhum.asserts.assertEquals(title, "Drash Land - Drash")
-      const bundle = text.includes(`<script src="/assets/bundles/drash.v1.x.js"></script>`)
-      Rhum.asserts.assertEquals(bundle, true)
-    })
+      const res = await fetch(`${url}/drash/v1.x`);
+      Rhum.asserts.assertEquals(res.status, 200);
+      Rhum.asserts.assertEquals(res.url, `${url}/drash/v1.x`);
+      const text = await res.text();
+      server.close();
+      const title = text.split("<title>")[1].split("</title>")[0];
+      Rhum.asserts.assertEquals(title, "Drash Land - Drash");
+      const bundle = text.includes(
+        `<script src="/assets/bundles/drash.v1.x.js"></script>`,
+      );
+      Rhum.asserts.assertEquals(bundle, true);
+    });
     Rhum.testCase("Responds with 200 for /dmm/v1.x", async () => {
-      await server.run(serverConfigs)
+      await server.run(serverConfigs);
       // Development
-      const res = await fetch(`${url}/dmm/v1.x`)
-      Rhum.asserts.assertEquals(res.status, 200)
-      Rhum.asserts.assertEquals(res.url, `${url}/dmm/v1.x`)
-      const text = await res.text()
-      server.close()
-      const title = text.split("<title>")[1].split("</title>")[0]
-      Rhum.asserts.assertEquals(title, "Drash Land - Dmm")
-      const bundle = text.includes(`<script src="/assets/bundles/dmm.v1.x.js"></script>`)
-      Rhum.asserts.assertEquals(bundle, true)
-    })
+      const res = await fetch(`${url}/dmm/v1.x`);
+      Rhum.asserts.assertEquals(res.status, 200);
+      Rhum.asserts.assertEquals(res.url, `${url}/dmm/v1.x`);
+      const text = await res.text();
+      server.close();
+      const title = text.split("<title>")[1].split("</title>")[0];
+      Rhum.asserts.assertEquals(title, "Drash Land - Dmm");
+      const bundle = text.includes(
+        `<script src="/assets/bundles/dmm.v1.x.js"></script>`,
+      );
+      Rhum.asserts.assertEquals(bundle, true);
+    });
     Rhum.testCase("Responds with 200 for /rhum/v1.x", async () => {
-      await server.run(serverConfigs)
-      const res = await fetch(`${url}/rhum/v1.x`)
-      Rhum.asserts.assertEquals(res.status, 200)
-      Rhum.asserts.assertEquals(res.url, `${url}/rhum/v1.x`)
-      const text = await res.text()
-      server.close()
-      const title = text.split("<title>")[1].split("</title>")[0]
-      Rhum.asserts.assertEquals(title, "Drash Land - Rhum")
-      const bundle = text.includes(`<script src="/assets/bundles/rhum.v1.x.js"></script>`)
-      Rhum.asserts.assertEquals(bundle, true)
-    })
+      await server.run(serverConfigs);
+      const res = await fetch(`${url}/rhum/v1.x`);
+      Rhum.asserts.assertEquals(res.status, 200);
+      Rhum.asserts.assertEquals(res.url, `${url}/rhum/v1.x`);
+      const text = await res.text();
+      server.close();
+      const title = text.split("<title>")[1].split("</title>")[0];
+      Rhum.asserts.assertEquals(title, "Drash Land - Rhum");
+      const bundle = text.includes(
+        `<script src="/assets/bundles/rhum.v1.x.js"></script>`,
+      );
+      Rhum.asserts.assertEquals(bundle, true);
+    });
     Rhum.testCase("Responds with 200 for /wocket/v0.x", async () => {
-      await server.run(serverConfigs)
-      const res = await fetch(`${url}/wocket/v0.x`)
-      Rhum.asserts.assertEquals(res.status, 302)
-      Rhum.asserts.assertEquals(res.url, `${url}/wocket/v0.x`)
-      const text = await res.text()
-      server.close()
-      const title = text.split("<title>")[1].split("</title>")[0]
-      Rhum.asserts.assertEquals(title, "Drash Land - Wocket")
-      const bundle = text.includes(`<script src="/assets/bundles/wocket.v0.x.js"></script>`)
-      Rhum.asserts.assertEquals(bundle, true)
-    })
+      await server.run(serverConfigs);
+      const res = await fetch(`${url}/wocket/v0.x`);
+      Rhum.asserts.assertEquals(res.status, 302);
+      Rhum.asserts.assertEquals(res.url, `${url}/wocket/v0.x`);
+      const text = await res.text();
+      server.close();
+      const title = text.split("<title>")[1].split("</title>")[0];
+      Rhum.asserts.assertEquals(title, "Drash Land - Wocket");
+      const bundle = text.includes(
+        `<script src="/assets/bundles/wocket.v0.x.js"></script>`,
+      );
+      Rhum.asserts.assertEquals(bundle, true);
+    });
     Rhum.testCase("Responds with 200 for /sinco/v1.x", async () => {
-      await server.run(serverConfigs)
-      const res = await fetch(`${url}/sinco`)
-      Rhum.asserts.assertEquals(res.status, 302)
-      Rhum.asserts.assertEquals(res.url, `${url}/sinco/v1.x`)
-      const text = await res.text()
-      server.close()
-      const title = text.split("<title>")[1].split("</title>")[0]
-      Rhum.asserts.assertEquals(title, "Drash Land - Sinco")
-      const bundle = text.includes(`<script src="/assets/bundles/sinco.v1.x.js"></script>`)
-      Rhum.asserts.assertEquals(bundle, true)
-    })
-    Rhum.testCase("Responds with 404 when `version` is not a recognised version for the module", async () => {
-      await server.run(serverConfigs)
-      const res = await fetch(`${url}/drash/hella`)
-      server.close()
-      Rhum.asserts.assertEquals(res.status, 404)
-      Rhum.asserts.assertEquals(res.url, `${url}/v1.x`) // fixme this will be wrong
-    })
-  })
-})
+      await server.run(serverConfigs);
+      const res = await fetch(`${url}/sinco`);
+      Rhum.asserts.assertEquals(res.status, 302);
+      Rhum.asserts.assertEquals(res.url, `${url}/sinco/v1.x`);
+      const text = await res.text();
+      server.close();
+      const title = text.split("<title>")[1].split("</title>")[0];
+      Rhum.asserts.assertEquals(title, "Drash Land - Sinco");
+      const bundle = text.includes(
+        `<script src="/assets/bundles/sinco.v1.x.js"></script>`,
+      );
+      Rhum.asserts.assertEquals(bundle, true);
+    });
+    Rhum.testCase(
+      "Responds with 404 when `version` is not a recognised version for the module",
+      async () => {
+        await server.run(serverConfigs);
+        const res = await fetch(`${url}/drash/hella`);
+        server.close();
+        Rhum.asserts.assertEquals(res.status, 404);
+        Rhum.asserts.assertEquals(res.url, `${url}/v1.x`); // fixme this will be wrong
+      },
+    );
+  });
+});
 
-Rhum.run()
+Rhum.run();

--- a/tests/integration/staging_module_resource_test.ts
+++ b/tests/integration/staging_module_resource_test.ts
@@ -7,7 +7,7 @@ const serverConfigs = {
 }
 const url = `http://${serverConfigs.hostname}:${serverConfigs.port}/staging`
 
-Rhum.testPlan("tests/integration/module_resource_test.ts", () => {
+Rhum.testPlan("tests/integration/staging_module_resource_test.ts", () => {
   Rhum.testSuite("GET /staging/:module", () => {
     Rhum.testCase("Responds with 302 and redirects to latest version when `module` is drash", async () => {
       await server.run(serverConfigs)
@@ -124,3 +124,5 @@ Rhum.testPlan("tests/integration/module_resource_test.ts", () => {
     })
   })
 })
+
+Rhum.run()

--- a/tests/integration/staging_module_resource_test.ts
+++ b/tests/integration/staging_module_resource_test.ts
@@ -1,0 +1,126 @@
+import { server } from "../../server.ts";
+import {Rhum} from "./deps.ts";
+
+const serverConfigs = {
+  hostname: "localhost",
+  port: 1447
+}
+const url = `http://${serverConfigs.hostname}:${serverConfigs.port}/staging`
+
+Rhum.testPlan("tests/integration/module_resource_test.ts", () => {
+  Rhum.testSuite("GET /staging/:module", () => {
+    Rhum.testCase("Responds with 302 and redirects to latest version when `module` is drash", async () => {
+      await server.run(serverConfigs)
+      const res = await fetch(`${url}/drash`)
+      server.close()
+      Rhum.asserts.assertEquals(res.status, 302)
+      Rhum.asserts.assertEquals(res.url, `${url}/drash/v1.x`)
+    })
+    Rhum.testCase("Responds with 302 redirects to latest version when `module` is dmm", async () => {
+      await server.run(serverConfigs)
+      const res = await fetch(`${url}/dmm`)
+      server.close()
+      Rhum.asserts.assertEquals(res.status, 302)
+      Rhum.asserts.assertEquals(res.url, `${url}/dmm/v1.x`)
+    })
+    Rhum.testCase("Responds with 302 redirects to latest version when `module` is rhum", async () => {
+      await server.run(serverConfigs)
+      const res = await fetch(`${url}/rhum`)
+      server.close()
+      Rhum.asserts.assertEquals(res.status, 302)
+      Rhum.asserts.assertEquals(res.url, `${url}/rhum/v1.x`)
+    })
+    Rhum.testCase("Responds with 302 redirects to latest version when `module` is wocket", async () => {
+      await server.run(serverConfigs)
+      const res = await fetch(`${url}/wocket`)
+      server.close()
+      Rhum.asserts.assertEquals(res.status, 302)
+      Rhum.asserts.assertEquals(res.url, `${url}/wocket/v0.x`)
+    })
+    Rhum.testCase("Responds with 302 redirects to latest version when `module` is sinco", async () => {
+      await server.run(serverConfigs)
+      const res = await fetch(`${url}/sinco`)
+      server.close()
+      Rhum.asserts.assertEquals(res.status, 302)
+      Rhum.asserts.assertEquals(res.url, `${url}/sinco/v1.x`)
+    })
+    Rhum.testCase("Responds with 404 when `module` is not a recognised module", async () => {
+      await server.run(serverConfigs)
+      const res = await fetch(`${url}/hella`)
+      server.close()
+      Rhum.asserts.assertEquals(res.status, 404)
+      Rhum.asserts.assertEquals(res.url, `${url}/v1.x`) // fixme this will be wrong
+    })
+  })
+  Rhum.testSuite("GET /staging/:module/:version", () => {
+    Rhum.testCase("Responds with 200 for /drash/v1.x", async () => {
+      await server.run(serverConfigs)
+      // Development
+      const res = await fetch(`${url}/drash/v1.x`)
+      Rhum.asserts.assertEquals(res.status, 200)
+      Rhum.asserts.assertEquals(res.url, `${url}/drash/v1.x`)
+      const text = await res.text()
+      server.close()
+      const title = text.split("<title>")[1].split("</title>")[0]
+      Rhum.asserts.assertEquals(title, "Drash Land - Drash")
+      const bundle = text.includes(`<script src="/assets/bundles/drash.v1.x.js"></script>`)
+      Rhum.asserts.assertEquals(bundle, true)
+    })
+    Rhum.testCase("Responds with 200 for /dmm/v1.x", async () => {
+      await server.run(serverConfigs)
+      // Development
+      const res = await fetch(`${url}/dmm/v1.x`)
+      Rhum.asserts.assertEquals(res.status, 200)
+      Rhum.asserts.assertEquals(res.url, `${url}/dmm/v1.x`)
+      const text = await res.text()
+      server.close()
+      const title = text.split("<title>")[1].split("</title>")[0]
+      Rhum.asserts.assertEquals(title, "Drash Land - Dmm")
+      const bundle = text.includes(`<script src="/assets/bundles/dmm.v1.x.js"></script>`)
+      Rhum.asserts.assertEquals(bundle, true)
+    })
+    Rhum.testCase("Responds with 200 for /rhum/v1.x", async () => {
+      await server.run(serverConfigs)
+      const res = await fetch(`${url}/rhum/v1.x`)
+      Rhum.asserts.assertEquals(res.status, 200)
+      Rhum.asserts.assertEquals(res.url, `${url}/rhum/v1.x`)
+      const text = await res.text()
+      server.close()
+      const title = text.split("<title>")[1].split("</title>")[0]
+      Rhum.asserts.assertEquals(title, "Drash Land - Rhum")
+      const bundle = text.includes(`<script src="/assets/bundles/rhum.v1.x.js"></script>`)
+      Rhum.asserts.assertEquals(bundle, true)
+    })
+    Rhum.testCase("Responds with 200 for /wocket/v0.x", async () => {
+      await server.run(serverConfigs)
+      const res = await fetch(`${url}/wocket/v0.x`)
+      Rhum.asserts.assertEquals(res.status, 302)
+      Rhum.asserts.assertEquals(res.url, `${url}/wocket/v0.x`)
+      const text = await res.text()
+      server.close()
+      const title = text.split("<title>")[1].split("</title>")[0]
+      Rhum.asserts.assertEquals(title, "Drash Land - Wocket")
+      const bundle = text.includes(`<script src="/assets/bundles/wocket.v0.x.js"></script>`)
+      Rhum.asserts.assertEquals(bundle, true)
+    })
+    Rhum.testCase("Responds with 200 for /sinco/v1.x", async () => {
+      await server.run(serverConfigs)
+      const res = await fetch(`${url}/sinco`)
+      Rhum.asserts.assertEquals(res.status, 302)
+      Rhum.asserts.assertEquals(res.url, `${url}/sinco/v1.x`)
+      const text = await res.text()
+      server.close()
+      const title = text.split("<title>")[1].split("</title>")[0]
+      Rhum.asserts.assertEquals(title, "Drash Land - Sinco")
+      const bundle = text.includes(`<script src="/assets/bundles/sinco.v1.x.js"></script>`)
+      Rhum.asserts.assertEquals(bundle, true)
+    })
+    Rhum.testCase("Responds with 404 when `version` is not a recognised version for the module", async () => {
+      await server.run(serverConfigs)
+      const res = await fetch(`${url}/drash/hella`)
+      server.close()
+      Rhum.asserts.assertEquals(res.status, 404)
+      Rhum.asserts.assertEquals(res.url, `${url}/v1.x`) // fixme this will be wrong
+    })
+  })
+})

--- a/tests/integration/staging_module_resource_test_old.ts
+++ b/tests/integration/staging_module_resource_test_old.ts
@@ -6,6 +6,7 @@ const serverConfigs = {
   port: 1447,
 };
 const url = `http://${serverConfigs.hostname}:${serverConfigs.port}/staging`;
+const urlWOStaging = `http://${serverConfigs.hostname}:${serverConfigs.port}`
 
 Rhum.testPlan("tests/integration/staging_module_resource_test.ts", () => {
   Rhum.testSuite("GET /staging/:module", () => {
@@ -14,9 +15,10 @@ Rhum.testPlan("tests/integration/staging_module_resource_test.ts", () => {
       async () => {
         await server.run(serverConfigs);
         const res = await fetch(`${url}/drash`);
+        await res.text()
         server.close();
-        Rhum.asserts.assertEquals(res.status, 302);
-        Rhum.asserts.assertEquals(res.url, `${url}/drash/v1.x`);
+        Rhum.asserts.assertEquals(res.status, 200);
+        Rhum.asserts.assertEquals(res.url, `${urlWOStaging}/drash/v1.x/`);
       },
     );
     Rhum.testCase(
@@ -24,19 +26,21 @@ Rhum.testPlan("tests/integration/staging_module_resource_test.ts", () => {
       async () => {
         await server.run(serverConfigs);
         const res = await fetch(`${url}/dmm`);
+        await res.text()
         server.close();
-        Rhum.asserts.assertEquals(res.status, 302);
-        Rhum.asserts.assertEquals(res.url, `${url}/dmm/v1.x`);
+        Rhum.asserts.assertEquals(res.status, 200);
+        Rhum.asserts.assertEquals(res.url, `${urlWOStaging}/dmm/v1.x/`);
       },
     );
     Rhum.testCase(
       "Responds with 302 redirects to latest version when `module` is rhum",
       async () => {
         await server.run(serverConfigs);
-        const res = await fetch(`${url}/rhum`);
+        const res = await fetch(`${url}/rhum`)
+        await res.text()
         server.close();
-        Rhum.asserts.assertEquals(res.status, 302);
-        Rhum.asserts.assertEquals(res.url, `${url}/rhum/v1.x`);
+        Rhum.asserts.assertEquals(res.status, 200);
+        Rhum.asserts.assertEquals(res.url, `${urlWOStaging}/rhum/v1.x/`);
       },
     );
     Rhum.testCase(
@@ -44,9 +48,10 @@ Rhum.testPlan("tests/integration/staging_module_resource_test.ts", () => {
       async () => {
         await server.run(serverConfigs);
         const res = await fetch(`${url}/wocket`);
+        await res.text()
         server.close();
-        Rhum.asserts.assertEquals(res.status, 302);
-        Rhum.asserts.assertEquals(res.url, `${url}/wocket/v0.x`);
+        Rhum.asserts.assertEquals(res.status, 200);
+        Rhum.asserts.assertEquals(res.url, `${urlWOStaging}/wocket/v0.x/`);
       },
     );
     Rhum.testCase(
@@ -54,9 +59,10 @@ Rhum.testPlan("tests/integration/staging_module_resource_test.ts", () => {
       async () => {
         await server.run(serverConfigs);
         const res = await fetch(`${url}/sinco`);
+        await res.text()
         server.close();
-        Rhum.asserts.assertEquals(res.status, 302);
-        Rhum.asserts.assertEquals(res.url, `${url}/sinco/v1.x`);
+        Rhum.asserts.assertEquals(res.status, 200);
+        Rhum.asserts.assertEquals(res.url, `${urlWOStaging}/sinco/v1.x/`);
       },
     );
     Rhum.testCase(
@@ -64,16 +70,16 @@ Rhum.testPlan("tests/integration/staging_module_resource_test.ts", () => {
       async () => {
         await server.run(serverConfigs);
         const res = await fetch(`${url}/hella`);
+        await res.text()
         server.close();
         Rhum.asserts.assertEquals(res.status, 404);
-        Rhum.asserts.assertEquals(res.url, `${url}/v1.x`); // fixme this will be wrong
+        Rhum.asserts.assertEquals(res.url, `${url}/hella`);
       },
     );
   });
   Rhum.testSuite("GET /staging/:module/:version", () => {
     Rhum.testCase("Responds with 200 for /drash/v1.x", async () => {
       await server.run(serverConfigs);
-      // Development
       const res = await fetch(`${url}/drash/v1.x`);
       Rhum.asserts.assertEquals(res.status, 200);
       Rhum.asserts.assertEquals(res.url, `${url}/drash/v1.x`);
@@ -91,7 +97,7 @@ Rhum.testPlan("tests/integration/staging_module_resource_test.ts", () => {
       // Development
       const res = await fetch(`${url}/dmm/v1.x`);
       Rhum.asserts.assertEquals(res.status, 200);
-      Rhum.asserts.assertEquals(res.url, `${url}/dmm/v1.x`);
+      Rhum.asserts.assertEquals(res.url, `${urlWOStaging}/dmm/v1.x`);
       const text = await res.text();
       server.close();
       const title = text.split("<title>")[1].split("</title>")[0];
@@ -118,8 +124,8 @@ Rhum.testPlan("tests/integration/staging_module_resource_test.ts", () => {
     Rhum.testCase("Responds with 200 for /wocket/v0.x", async () => {
       await server.run(serverConfigs);
       const res = await fetch(`${url}/wocket/v0.x`);
-      Rhum.asserts.assertEquals(res.status, 302);
-      Rhum.asserts.assertEquals(res.url, `${url}/wocket/v0.x`);
+      Rhum.asserts.assertEquals(res.status, 200);
+      Rhum.asserts.assertEquals(res.url, `${urlWOStaging}/wocket/v0.x`);
       const text = await res.text();
       server.close();
       const title = text.split("<title>")[1].split("</title>")[0];
@@ -131,9 +137,9 @@ Rhum.testPlan("tests/integration/staging_module_resource_test.ts", () => {
     });
     Rhum.testCase("Responds with 200 for /sinco/v1.x", async () => {
       await server.run(serverConfigs);
-      const res = await fetch(`${url}/sinco`);
+      const res = await fetch(`${url}/sinco/v1.x`);
       Rhum.asserts.assertEquals(res.status, 302);
-      Rhum.asserts.assertEquals(res.url, `${url}/sinco/v1.x`);
+      Rhum.asserts.assertEquals(res.url, `${urlWOStaging}/sinco/v1.x`)
       const text = await res.text();
       server.close();
       const title = text.split("<title>")[1].split("</title>")[0];
@@ -148,9 +154,10 @@ Rhum.testPlan("tests/integration/staging_module_resource_test.ts", () => {
       async () => {
         await server.run(serverConfigs);
         const res = await fetch(`${url}/drash/hella`);
+        await res.text()
         server.close();
         Rhum.asserts.assertEquals(res.status, 404);
-        Rhum.asserts.assertEquals(res.url, `${url}/v1.x`); // fixme this will be wrong
+        Rhum.asserts.assertEquals(res.url, `${url}/drash/hella`);
       },
     );
   });


### PR DESCRIPTION
## Summary

* Add tests
* Add ci workflow for linting, running tests, ensuring server runs and npm scripts work
* Update readme
* Removed staging module resource as it isn't used anymore due to separate staging server (kept the logic for this, just removed any code that used it)

## Other Notes
* All webpack files should be able to become one, as the only difference between the dev and prod files are a single line (the environment)
* The module and staging module resource GET methods seem to use the same logic - turn contents into a reusable method?
* Should we remove denon and use `--watch`?
* Need to add test deps to bumper when this mr is merged