### PR TITLE
chore: Add pa11y for accessibility testing

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -9,6 +9,27 @@ on:
       - main
 
 jobs:
+  accessibility:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Deno
+        uses: denolib/setup-deno@v2
+
+      - name: Accessibility Tests
+        run: |
+          npm i -g pa11y
+          npm run webpack:development
+          npm run server &
+          sleep 5;
+          pa11y --ignore "WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Fail" http://localhost:1445
+          pa11y --ignore "WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Fail" http://localhost:1445/drash
+          pa11y --ignore "WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Fail" http://localhost:1445/dmm
+          pa11y --ignore "WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Fail" http://localhost:1445/wocket
+          pa11y --ignore "WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Fail" http://localhost:1445/sinco
+          pa11y --ignore "WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Fail" http://localhost:1445/rhum
+
   tests:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -19,16 +19,13 @@ jobs:
 
       - name: Accessibility Tests
         run: |
-          npm i -g pa11y
           npm run webpack:development
+          npm i pa11y
           npm run server &
-          sleep 5;
-          pa11y --ignore "WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Fail" http://localhost:1445
-          pa11y --ignore "WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Fail" http://localhost:1445/drash
-          pa11y --ignore "WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Fail" http://localhost:1445/dmm
-          pa11y --ignore "WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Fail" http://localhost:1445/wocket
-          pa11y --ignore "WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Fail" http://localhost:1445/sinco
-          pa11y --ignore "WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Fail" http://localhost:1445/rhum
+          sleep 10;
+          node_modules/.bin/pa11y --ignore "WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Fail" http://localhost:1445
+#         Were only testing one, because all module pages are the same
+          node_modules/.bin/pa11y --ignore "WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Fail" http://localhost:1445/drash
 
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -24,7 +24,6 @@ jobs:
           npm run server &
           sleep 10
           node_modules/.bin/pa11y --ignore "WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Fail" http://localhost:1445
-#          Were only testing one, because all module pages are the same
           node_modules/.bin/pa11y --ignore "WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Fail" http://localhost:1445/drash
 
   tests:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -22,9 +22,9 @@ jobs:
           npm run webpack:development
           npm i pa11y
           npm run server &
-          sleep 10;
+          sleep 10
           node_modules/.bin/pa11y --ignore "WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Fail" http://localhost:1445
-#         Were only testing one, because all module pages are the same
+#          Were only testing one, because all module pages are the same
           node_modules/.bin/pa11y --ignore "WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Fail" http://localhost:1445/drash
 
   tests:

--- a/assets/common/vue/app_root.vue
+++ b/assets/common/vue/app_root.vue
@@ -240,11 +240,13 @@ div(
     button(
       :class="{'mr-3': is_mobile, 'hide': !can_scroll_to_top}"
       type="button", @click="scrollToTop()"
+      title="Scroll to top"
     )
       i.fa.fa-arrow-up
     button.open-sidebar(
       :class="{'hide': !is_mobile}"
       type="button", @click="toggleSidebar()"
+      title="Open Sidebar"
     )
         i.fa.fa-bars(
           :class="{'hide': open_sidebar}"

--- a/src/views/landing.html
+++ b/src/views/landing.html
@@ -207,7 +207,7 @@
               <div class="row">
                 <div class="col-lg-4 col-md-6">
                   <a href="/drash/" class="card integration-card text-center p-3">
-                    <img height="150" src="/assets/common/img/logo_drash.svg">
+                    <img height="150" src="/assets/common/img/logo_drash.svg" alt="Drash Logo">
                     <div class="card-header">
                       <h4>Drash</h4>
                       <span class="integration-type">A REST microframework</span>
@@ -216,7 +216,7 @@
                 </div>
                 <div class="col-lg-4 col-md-6">
                   <a href="https://github.com/drashland/deno-drash-middleware" class="card integration-card text-center p-3">
-                    <img height="150" src="/assets/common/img/logo_drash_middleware.svg">
+                    <img height="150" src="/assets/common/img/logo_drash_middleware.svg" alt="Drash Middleware Logo">
                     <div class="card-header">
                       <h4>Drash Middleware</h4>
                       <span class="integration-type">A middleware library for Drash</span>
@@ -225,7 +225,7 @@
                 </div>
                 <div class="col-lg-4 col-md-6">
                   <a href="/wocket/" class="card integration-card text-center p-3">
-                    <img height="150" src="/assets/common/img/logo_wocket.svg">
+                    <img height="150" src="/assets/common/img/logo_wocket.svg" alt="Wocket Logo">
                     <div class="card-header">
                       <h4>Wocket</h4>
                       <span class="integration-type">A WebSocket library</span>
@@ -234,7 +234,7 @@
                 </div>
                 <div class="col-lg-4 col-md-6">
                   <a href="/dmm/" class="card integration-card text-center p-3">
-                    <img height="150" src="/assets/common/img/logo_dmm.svg">
+                    <img height="150" src="/assets/common/img/logo_dmm.svg" alt="Dmm Logo">
                     <div class="card-header">
                       <h4>dmm</h4>
                       <span class="integration-type">A lightweight module manager</span>
@@ -243,7 +243,7 @@
                 </div>
                 <div class="col-lg-4 col-md-6">
                   <a href="/rhum/" class="card integration-card text-center p-3">
-                    <img height="150" src="/assets/common/img/logo_rhum.svg">
+                    <img height="150" src="/assets/common/img/logo_rhum.svg" alt="Rhum logo">
                     <div class="card-header">
                       <h4>Rhum</h4>
                       <span class="integration-type">A lightweight testing framework</span>
@@ -252,7 +252,7 @@
                 </div>
                 <div class="col-lg-4 col-md-6">
                   <a href="/sinco/" class="card integration-card text-center p-3">
-                    <img height="150" src="/assets/common/img/logo_sinco.svg">
+                    <img height="150" src="/assets/common/img/logo_sinco.svg" alt="Sinco Logo">
                     <div class="card-header">
                       <h4>Sinco</h4>
                       <span class="integration-type">Browser automation and testing tool</span>
@@ -288,9 +288,7 @@
               <header class="section-header text-center u-text--light">
                 <p class="lead">Develop with confidence.</p>
                 <p>Released under the MIT License.</p>
-                <a href="https://github.com/drashland" target="_BLANK" class="text-white mb-3">
-                  <i class="fab fa-github fa-3x"></i>
-                </a>
+                <span id="github-icon" data-url="https://github.com/drashland" class="text-white mb-3 fab fa-github fa-3x"></span>
               </header>
             </div>
           </div>
@@ -334,6 +332,9 @@
           let json = await res.json();
           json = json.slice(0, 6);
           this.news = json;
+          document.getElementById("github-icon").addEventListener("click", (e) => {
+            window.open(e.target.dataset.url)
+          })
         },
       });
       const vm = app.mount("#app");

--- a/src/views/module.html
+++ b/src/views/module.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=0"/>


### PR DESCRIPTION
Fixes #200 

## Summary

* Uses pa11y instead of axe-core, the output generated is prettier imo
* Only tests landing and drash page, because all modules share the same page, so makes no sense to retest the same page 5 times