### PR TITLE
docs(drash): Fix markup being escaped in example code

### DIFF
--- a/console/compile_vue_routes.js
+++ b/console/compile_vue_routes.js
@@ -31,7 +31,7 @@ modules.forEach((moduleAndVersion) => {
     const files = fs.readdirSync(directory);
     for (let index in files) {
       const file = files[index];
-      const filepath = path.join(directory, file);
+      const filepath = directory + "/" + file; // This was path.join(directory, file), but it was causing issues for windows, and the resulting string would be ./src\modules\dmm-v1.x\vue\pages\..., as you can see, it replaces the / and uses an escape character, so when it gets written to the compiled routes file, the import lines look like `import * as name_1 from "/src\modules\...", so when webpack tries to bundle, it sees these as `/srcmodulesdmm-v1.x`
       const stats = fs.statSync(filepath);
       const filenameWithoutExtension = path.basename(filepath).split(".")[0];
       const filepathKebabCase =
@@ -40,7 +40,7 @@ modules.forEach((moduleAndVersion) => {
         walk(filepath);
       } else if (stats.isFile()) {
         importString += `
-  import * as ${filenameWithoutExtension}_${count} from "/${filepath}";`;
+  import * as ${filenameWithoutExtension}_${count} from "${filepath.substring(1)}";`; // Using substring to remove the `.` from the start
         exportString += `  ${filenameWithoutExtension}_${count},\n`;
       }
       count += 1;
@@ -49,6 +49,5 @@ modules.forEach((moduleAndVersion) => {
 
   walk(directory);
   exportString += `];`;
-
   fs.writeFileSync(outFile, importString + exportString);
 });

--- a/src/modules/drash-v1.x/vue/pages/tutorials/requests/handling_forms_and_file_uploads.vue
+++ b/src/modules/drash-v1.x/vue/pages/tutorials/requests/handling_forms_and_file_uploads.vue
@@ -6,29 +6,28 @@ export const resource = {
   }
 }
 
-const public_index_html =
-  `<!DOCTYPE html>
-   <html>
-   <head></head>
-   <body>
-       <form>
-            <input name="username" type="text">
-            <input type="file" name="profile-picture">
-            <button id="submit" type="button">Submit</button>
-       </form>
-       <script>
-           window.addEventListener("DOMContentLoaded", () => {
-             document.getElementById("submit").addEventListener("click", async () => {
-               const form = document.querySelector("form");
-               await fetch("http://localhost:1447/profile", {
-                 method:  "POST",
-                 body: new FormData(form)
-               });
-             });
-           });
-       <\/script>
-    </body>
-    </html>`
+const public_index_html =`<!DOCTYPE html>
+<html>
+  <head></head>
+  <body>
+    <form>
+      <input name="username" type="text">
+      <input type="file" name="profile-picture">
+      <button id="submit" type="button">Submit</button>
+    </form>
+    <script>
+      window.addEventListener("DOMContentLoaded", () => {
+        document.getElementById("submit").addEventListener("click", async () => {
+          const form = document.querySelector("form");
+          await fetch("http://localhost:1447/profile", {
+            method:  "POST",
+            body: new FormData(form)
+          });
+        });
+      });
+    <\/script>
+  </body>
+</html>`
 
 export default {
   data() {

--- a/src/modules/drash-v1.x/vue/pages/tutorials/servers/serving_static_paths.vue
+++ b/src/modules/drash-v1.x/vue/pages/tutorials/servers/serving_static_paths.vue
@@ -7,6 +7,17 @@ export const resource = {
   }
 }
 
+const html = `<!DOCTYPE html>
+      <html>
+        <head>
+          <title>Drash</title>
+          <link href="/public/style.css" rel="stylesheet">
+        </head>
+        <body>
+          <h1 class="my-text">This is my title and it is red.</h1>
+        </body>
+      </html>`;
+
 export default {
   data() {
     return {
@@ -16,7 +27,8 @@ export default {
         "Folder Structure End State",
         "Steps",
         "Verification"
-      ]
+      ],
+      html: html
     };
   },
 }
@@ -76,17 +88,7 @@ page(
         |   static paths = ["/"];
         | 
         |   public GET() {
-        |     this.response.body = `
-        |     <!DOCTYPE html>
-        |     <html>
-        |       <head>
-        |         <title>Drash</title>
-        |         <link href="/public/style.css" rel="stylesheet">
-        |       </head>
-        |       <body>
-        |         <h1 class="my-text">This is my title and it is red.</h1>
-        |       </body>
-        |     </html>`;
+        |     this.response.body = `{{ html }}`;
         | 
         |     return this.response;
         |   }

--- a/src/modules/drash-v1.x/vue/pages/tutorials/servers/serving_virtual_paths.vue
+++ b/src/modules/drash-v1.x/vue/pages/tutorials/servers/serving_virtual_paths.vue
@@ -7,6 +7,17 @@ export const resource = {
   }
 }
 
+const html = `<!DOCTYPE html>
+      <html>
+        <head>
+          <title>Drash</title>
+          <link href="/assets/style.css" rel="stylesheet">
+        </head>
+        <body>
+          <h1 class="my-text">This is my title and it is red.</h1>
+        </body>
+      </html>`
+
 export default {
   data() {
     return {
@@ -16,7 +27,8 @@ export default {
         "Folder Structure End State",
         "Steps",
         "Verification"
-      ]
+      ],
+      html: html
     };
   },
 }
@@ -84,17 +96,7 @@ page(
         |   static paths = ["/"];
         | 
         |   public GET() {
-        |     this.response.body = `
-        |     <!DOCTYPE html>
-        |     <html>
-        |       <head>
-        |         <title>Drash</title>
-        |         <link href="/assets/style.css" rel="stylesheet">
-        |       </head>
-        |       <body>
-        |         <h1 class="my-text">This is my title and it is red.</h1>
-        |       </body>
-        |     </html>`;
+        |     this.response.body = `{{ html }}`;
         | 
         |     return this.response;
         |   }


### PR DESCRIPTION
Addresses #370 and #371

## Summary

* Also fixes issues i was having with using webpack to bundle files (https://discord.com/channels/685532342869295145/698487176597602365/819307351113990194)
