### PR TITLE
[#399] fixing the extra hash-sign in the link path (Sinco)

### DIFF
--- a/src/modules/sinco-v1.x/vue/pages/tutorials/clicking_elements.vue
+++ b/src/modules/sinco-v1.x/vue/pages/tutorials/clicking_elements.vue
@@ -15,7 +15,7 @@ export default {
   },
   data() {
     return {
-      base_url: this.$conf.sinco.base_url + "/#",
+      base_url: this.$conf.sinco.base_url,
       title: title,
       toc: [
         "Before You Get Started",

--- a/src/modules/sinco-v1.x/vue/pages/tutorials/custom_assertions.vue
+++ b/src/modules/sinco-v1.x/vue/pages/tutorials/custom_assertions.vue
@@ -16,7 +16,7 @@ export default {
   },
   data() {
     return {
-      base_url: this.$conf.sinco.base_url + "/#",
+      base_url: this.$conf.sinco.base_url,
       title: title,
       toc: [
         "Before You Get Started",

--- a/src/modules/sinco-v1.x/vue/pages/tutorials/evaluate_page.vue
+++ b/src/modules/sinco-v1.x/vue/pages/tutorials/evaluate_page.vue
@@ -15,7 +15,7 @@ export default {
   },
   data() {
     return {
-      base_url: this.$conf.sinco.base_url + "/#",
+      base_url: this.$conf.sinco.base_url,
       title: title,
       toc: [
         "Before You Get Started",

--- a/src/modules/sinco-v1.x/vue/pages/tutorials/get_and_set_input_value.vue
+++ b/src/modules/sinco-v1.x/vue/pages/tutorials/get_and_set_input_value.vue
@@ -16,7 +16,7 @@ export default {
   },
   data() {
     return {
-      base_url: this.$conf.sinco.base_url + "/#",
+      base_url: this.$conf.sinco.base_url,
       title: title,
       toc: [
         "Before You Get Started",

--- a/src/modules/sinco-v1.x/vue/pages/tutorials/using_within_docker.vue
+++ b/src/modules/sinco-v1.x/vue/pages/tutorials/using_within_docker.vue
@@ -15,7 +15,7 @@ export default {
   },
   data() {
     return {
-      base_url: this.$conf.sinco.base_url + "/#",
+      base_url: this.$conf.sinco.base_url,
       title: title,
       toc: [
         "Before You Get Started",

--- a/src/modules/sinco-v1.x/vue/pages/tutorials/visit_pages.vue
+++ b/src/modules/sinco-v1.x/vue/pages/tutorials/visit_pages.vue
@@ -15,7 +15,7 @@ export default {
   },
   data() {
     return {
-      base_url: this.$conf.sinco.base_url + "/#",
+      base_url: this.$conf.sinco.base_url,
       title: title,
       toc: [
         "Before You Get Started",

--- a/src/modules/sinco-v1.x/vue/pages/tutorials/waiting.vue
+++ b/src/modules/sinco-v1.x/vue/pages/tutorials/waiting.vue
@@ -15,7 +15,7 @@ export default {
   },
   data() {
     return {
-      base_url: this.$conf.sinco.base_url + "/#",
+      base_url: this.$conf.sinco.base_url,
       title: title,
       toc: [
         "Before You Get Started",

--- a/src/modules/sinco-v2.x/vue/pages/tutorials/clicking_elements.vue
+++ b/src/modules/sinco-v2.x/vue/pages/tutorials/clicking_elements.vue
@@ -15,7 +15,7 @@ export default {
   },
   data() {
     return {
-      base_url: this.$conf.sinco.base_url + "/#",
+      base_url: this.$conf.sinco.base_url,
       title: title,
       toc: [
         "Before You Get Started",

--- a/src/modules/sinco-v2.x/vue/pages/tutorials/creating_a_client.vue
+++ b/src/modules/sinco-v2.x/vue/pages/tutorials/creating_a_client.vue
@@ -15,7 +15,7 @@ export default {
   },
   data() {
     return {
-      base_url: this.$conf.sinco.base_url + "/#",
+      base_url: this.$conf.sinco.base_url,
       title: title,
       toc: [
         "Before You Get Started",

--- a/src/modules/sinco-v2.x/vue/pages/tutorials/custom_assertions.vue
+++ b/src/modules/sinco-v2.x/vue/pages/tutorials/custom_assertions.vue
@@ -16,7 +16,7 @@ export default {
   },
   data() {
     return {
-      base_url: this.$conf.sinco.base_url + "/#",
+      base_url: this.$conf.sinco.base_url,
       title: title,
       toc: [
         "Before You Get Started",

--- a/src/modules/sinco-v2.x/vue/pages/tutorials/evaluate_page.vue
+++ b/src/modules/sinco-v2.x/vue/pages/tutorials/evaluate_page.vue
@@ -15,7 +15,7 @@ export default {
   },
   data() {
     return {
-      base_url: this.$conf.sinco.base_url + "/#",
+      base_url: this.$conf.sinco.base_url,
       title: title,
       toc: [
         "Before You Get Started",

--- a/src/modules/sinco-v2.x/vue/pages/tutorials/get_and_set_input_value.vue
+++ b/src/modules/sinco-v2.x/vue/pages/tutorials/get_and_set_input_value.vue
@@ -16,7 +16,7 @@ export default {
   },
   data() {
     return {
-      base_url: this.$conf.sinco.base_url + "/#",
+      base_url: this.$conf.sinco.base_url,
       title: title,
       toc: [
         "Before You Get Started",

--- a/src/modules/sinco-v2.x/vue/pages/tutorials/using_within_docker.vue
+++ b/src/modules/sinco-v2.x/vue/pages/tutorials/using_within_docker.vue
@@ -15,7 +15,7 @@ export default {
   },
   data() {
     return {
-      base_url: this.$conf.sinco.base_url + "/#",
+      base_url: this.$conf.sinco.base_url,
       title: title,
       toc: [
         "Before You Get Started",

--- a/src/modules/sinco-v2.x/vue/pages/tutorials/visit_pages.vue
+++ b/src/modules/sinco-v2.x/vue/pages/tutorials/visit_pages.vue
@@ -15,7 +15,7 @@ export default {
   },
   data() {
     return {
-      base_url: this.$conf.sinco.base_url + "/#",
+      base_url: this.$conf.sinco.base_url,
       title: title,
       toc: [
         "Before You Get Started",

--- a/src/modules/sinco-v2.x/vue/pages/tutorials/waiting.vue
+++ b/src/modules/sinco-v2.x/vue/pages/tutorials/waiting.vue
@@ -15,7 +15,7 @@ export default {
   },
   data() {
     return {
-      base_url: this.$conf.sinco.base_url + "/#",
+      base_url: this.$conf.sinco.base_url,
       title: title,
       toc: [
         "Before You Get Started",


### PR DESCRIPTION
Fixes #399 

## Summary

* Removed the extra '#' signs in the path from the vue files

## Other Notes

Write other useful information about this pull request here
