### PR TITLE
fix: Clicking links after selecting older versions direct to latest doc pages

### DIFF
--- a/assets/common/js/util.js
+++ b/assets/common/js/util.js
@@ -1,0 +1,4 @@
+export function selectedVersion() {
+  const version = window.location.pathname.split("/")[2];
+  return version;
+}

--- a/src/modules/dmm-v1.x/vue/app.vue
+++ b/src/modules/dmm-v1.x/vue/app.vue
@@ -1,5 +1,6 @@
 <script>
 import AppRoot from "/assets/common/vue/app_root.vue";
+import { selectedVersion } from "/assets/common/js/util.js"
 
 export default {
   components: {
@@ -8,7 +9,7 @@ export default {
   data() {
     return {
       sidebar: {
-        base_url: this.$conf.dmm.base_url,
+        base_url: "/dmm/" + selectedVersion(),
         github_href: "https://github.com/drashland/dmm",
         logo: "/assets/common/img/logo_dmm.svg",
         menus: {

--- a/src/modules/drash-v1.x/vue/app.vue
+++ b/src/modules/drash-v1.x/vue/app.vue
@@ -1,5 +1,6 @@
 <script>
 import AppRoot from "/assets/common/vue/app_root.vue";
+import { selectedVersion } from "/assets/common/js/util.js"
 
 export default {
   components: {
@@ -10,7 +11,7 @@ export default {
       articles: [],
       sidebar: {
         api_reference_href: "/drash/v1.x/#/api-reference",
-        base_url: this.$conf.drash.base_url,
+        base_url: "/drash/" + selectedVersion(),
         github_href: "https://github.com/drashland/deno-drash",
         logo: "/assets/common/img/logo_drash.svg",
         menus: {

--- a/src/modules/rhum-v1.x/vue/app.vue
+++ b/src/modules/rhum-v1.x/vue/app.vue
@@ -1,6 +1,6 @@
 <script>
 import AppRoot from "/assets/common/vue/app_root.vue";
-
+import { selectedVersion } from "/assets/common/js/util.js"
 
 export default {
   components: {
@@ -10,7 +10,7 @@ export default {
     return {
       sidebar: {
         api_reference_href: "https://doc.deno.land/https/deno.land/x/rhum@" + this.$conf.rhum.latest_version + "/mod.ts",
-        base_url: this.$conf.rhum.base_url,
+        base_url: "/rhum/" + selectedVersion(),
         github_href: "https://github.com/drashland/rhum",
         logo: "/assets/common/img/logo_rhum.svg",
         menus: {

--- a/src/modules/sinco-v1.x/vue/app.vue
+++ b/src/modules/sinco-v1.x/vue/app.vue
@@ -1,5 +1,6 @@
 <script>
 import AppRoot from "/assets/common/vue/app_root.vue";
+import { selectedVersion } from "/assets/common/js/util.js";
 
 export default {
   components: {
@@ -9,7 +10,7 @@ export default {
     return {
       sidebar: {
         api_reference_href: "https://doc.deno.land/https/deno.land/x/sinco@" + this.$conf.sinco.latest_version + "/mod.ts",
-        base_url: this.$conf.sinco.base_url,
+        base_url: "/sinco/" + selectedVersion(),
         github_href: "https://github.com/drashland/sinco",
         logo: "/assets/common/img/logo_sinco.svg",
         menus: {

--- a/src/modules/sinco-v2.x/vue/app.vue
+++ b/src/modules/sinco-v2.x/vue/app.vue
@@ -1,5 +1,6 @@
 <script>
 import AppRoot from "/assets/common/vue/app_root.vue";
+import { selectedVersion } from "/assets/common/js/util.js"
 
 export default {
   components: {
@@ -9,7 +10,7 @@ export default {
     return {
       sidebar: {
         api_reference_href: "https://doc.deno.land/https/deno.land/x/sinco@" + this.$conf.sinco.latest_version + "/mod.ts",
-        base_url: this.$conf.sinco.base_url,
+        base_url: "/sinco/" + selectedVersion(),
         github_href: "https://github.com/drashland/sinco",
         logo: "/assets/common/img/logo_sinco.svg",
         menus: {

--- a/src/modules/wocket-v0.x/vue/app.vue
+++ b/src/modules/wocket-v0.x/vue/app.vue
@@ -1,5 +1,6 @@
 <script>
 import AppRoot from "/assets/common/vue/app_root.vue";
+import { selectedVersion } from "/assets/common/js/util.js"
 
 export default {
   components: {
@@ -9,7 +10,7 @@ export default {
     return {
       sidebar: {
         api_reference_href: "https://doc.deno.land/https/deno.land/x/wocket@" + this.$conf.wocket.latest_version + "/mod.ts",
-        base_url: this.$conf.wocket.base_url,
+        base_url: "/wocket/" + selectedVersion(),
         github_href: "https://github.com/drashland/wocket",
         logo: "/assets/common/img/logo_wocket.svg",
         menus: {


### PR DESCRIPTION
Fixes #403 

(Bloody windows and vscode...)