### PR TITLE
chore: Add resource support for playground

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -1,6 +1,7 @@
 import { Drash } from "./deps.ts";
 import { LandingResource } from "./src/resources/landing_resource.ts";
 import { ModuleResource } from "./src/resources/module_resource.ts";
+import { PlaygroundResource } from "./src/resources/playground_resource.ts";
 import { Response } from "./src/response.ts";
 
 Drash.Http.Response = Response;
@@ -9,6 +10,7 @@ export const server = new Drash.Http.Server({
   resources: [
     LandingResource,
     ModuleResource,
+    PlaygroundResource
   ],
   response_output: "text/html",
   static_paths: {

--- a/src/resources/playground_resource.ts
+++ b/src/resources/playground_resource.ts
@@ -1,0 +1,15 @@
+import { BaseResource } from "./base_resource.ts";
+
+export class PlaygroundResource extends BaseResource {
+  static paths = [
+    "/playground",
+  ];
+
+  //////////////////////////////////////////////////////////////////////////////
+  // FILE MARKER - METHODS - HTTP //////////////////////////////////////////////
+  //////////////////////////////////////////////////////////////////////////////
+
+  public async GET() {
+      this.response.redirect(302, "http://localhost:1447/")
+  }
+}


### PR DESCRIPTION
Tested it and it seems to work, i had the repos setup like:

```
D:/Development/drashland/
  website/
  playground/
```

Ran both servers (docker for playground) and our resource did redirect to the playground site
