### PR TITLE
chore: Add unilogger to landing page

### DIFF
--- a/src/views/landing.html
+++ b/src/views/landing.html
@@ -276,7 +276,7 @@
                 <div class="col-lg-4 col-md-6">
                   <a href="https://github.com/drashland/unilogger" class="card integration-card text-center p-3">
                     <!-- TODO :: Replace below div with img tag once logo is created: <img height="150" src="/assets/common/img/logo_unilogger.svg" alt="Unilogger logo"> -->
-                    <div style="height: 150px; width: 150px"></div>
+                    <p style="height: 150px; width: 150px; margin: auto;">Logo yet to be created.</p>
                     <div class="card-header">
                       <h4>Unilogger</h4>
                       <span class="integration-type">Logger utility module for Deno</span>

--- a/src/views/landing.html
+++ b/src/views/landing.html
@@ -273,6 +273,16 @@
                     </div>
                   </a>
                 </div>
+                <div class="col-lg-4 col-md-6">
+                  <a href="https://github.com/drashland/unilogger" class="card integration-card text-center p-3">
+                    <!-- TODO :: Replace below div with img tag once logo is created: <img height="150" src="/assets/common/img/logo_unilogger.svg" alt="Unilogger logo"> -->
+                    <div style="height: 150px; width: 150px"></div>
+                    <div class="card-header">
+                      <h4>Unilogger</h4>
+                      <span class="integration-type">Logger utility module for Deno</span>
+                    </div>
+                  </a>
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
As we don't have a logo yet, there is text instead:

![image](https://user-images.githubusercontent.com/47337480/124837914-b1185500-df7d-11eb-9fcc-828b378aac90.png)

